### PR TITLE
Fix release build error on iOS

### DIFF
--- a/ios/BreathlyTests/BreathlyTests.m
+++ b/ios/BreathlyTests/BreathlyTests.m
@@ -40,11 +40,13 @@
   BOOL foundElement = NO;
 
   __block NSString *redboxError = nil;
-  RCTSetLogFunction(^(RCTLogLevel level, RCTLogSource source, NSString *fileName, NSNumber *lineNumber, NSString *message) {
-    if (level >= RCTLogLevelError) {
-      redboxError = message;
-    }
-  });
+  #ifdef DEBUG
+    RCTSetLogFunction(^(RCTLogLevel level, RCTLogSource source, NSString *fileName, NSNumber *lineNumber, NSString *message) {
+      if (level >= RCTLogLevelError) {
+        redboxError = message;
+      }
+    });
+  #endif
 
   while ([date timeIntervalSinceNow] > 0 && !foundElement && !redboxError) {
     [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
@@ -58,7 +60,9 @@
     }];
   }
 
-  RCTSetLogFunction(RCTDefaultLogFunction);
+  #ifdef DEBUG
+    RCTSetLogFunction(RCTDefaultLogFunction);
+  #endif
 
   XCTAssertNil(redboxError, @"RedBox error: %@", redboxError);
   XCTAssertTrue(foundElement, @"Couldn't find element with text '%@' in %d seconds", TEXT_TO_LOOK_FOR, TIMEOUT_SECONDS);


### PR DESCRIPTION
There's an issue on `react-native@0.60.4` that causes an error to happen when you build the iOS app in release mode.  
It will be fixed by [this PR](https://github.com/facebook/react-native/issues/25911) so in the meanwhile I applied the patch manually.   

The error is:
```
Undefined symbols for architecture x86_64:
"_RCTSetLogFunction", referenced from:
-[[projectname]Tests testRendersWelcomeScreen] in [projectname]Tests.o
ld: symbol(s) not found for architecture x86_64
```