### PR TITLE
Disabled hermes to fix the app being stuck on splash screen (Android)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -77,7 +77,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
-    enableHermes: true,  // clean and rebuild if changing
+    enableHermes: false,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
Currently you can't enable Hermes if you're using separate build per CPU architecture in Android (aka "app bundle"). Doing so causes the app to be stuck in the splash screen.  
Disabling it for now. 