### PR TITLE
Increase vibration duration on Android

### DIFF
--- a/src/screens/exercise-screen/use-exercise-haptics.tsx
+++ b/src/screens/exercise-screen/use-exercise-haptics.tsx
@@ -16,7 +16,7 @@ export const useExerciseHaptics = (
           } else if (Platform.OS === "android") {
             // `expo-haptics` doesn't provide a vibration pattern "soft" enough for my tastes on
             // Android so I fallback to the Vibration API.
-            Vibration.vibrate(20);
+            Vibration.vibrate(100);
           }
         }
       }


### PR DESCRIPTION
Got a report of the vibration not working on Android and I suspect is because of the low vibration duration I was using. Let's increase it to at least 100ms. 