### PR TITLE
Add Color Options to Rotating Circle

### DIFF
--- a/src/design/colors.ts
+++ b/src/design/colors.ts
@@ -14,10 +14,14 @@ export const colors = {
   "blue-400": tailwindColors.blue[400], // Android settings tint
   "blue-500": tailwindColors.blue[500], // iOS settings tint
   pastel: {
-    orange: "#F2CAAD", // Home screen planet
+    orange: "#F2CAAD", // Home screen planet, breathing animation shape default
     gray: "#E1E3DC", // Home screen planet
     green: "#ECE9B7", // Home screen planet
     "orange-light": "#F1E0D9", // Home screen button
     "gray-light": "#E7E9E6", // Home screen button
+    "blue-light": "#ADD8E6", // Breathing animation shape blue
+    lilac: "#D8B9FF", // Breathing animation shape lilac
+    pink: "#FFB6C1", // Breathing animation shape pink
+    "blue-dark": "#0054DB", // Breathing animation shape dark blue
   },
 };

--- a/src/design/colors.ts
+++ b/src/design/colors.ts
@@ -14,14 +14,14 @@ export const colors = {
   "blue-400": tailwindColors.blue[400], // Android settings tint
   "blue-500": tailwindColors.blue[500], // iOS settings tint
   pastel: {
-    orange: "#F2CAAD", // Home screen planet, breathing animation shape default
+    orange: "#F2CAAD", // Home screen planet, rotating circle default
     gray: "#E1E3DC", // Home screen planet
     green: "#ECE9B7", // Home screen planet
     "orange-light": "#F1E0D9", // Home screen button
     "gray-light": "#E7E9E6", // Home screen button
-    "blue-light": "#ADD8E6", // Breathing animation shape blue
-    lilac: "#D8B9FF", // Breathing animation shape lilac
-    pink: "#FFB6C1", // Breathing animation shape pink
-    "blue-dark": "#0054DB", // Breathing animation shape dark blue
+    "blue-light": "#ADD8E6", // Rotating circle blue
+    lilac: "#D8B9FF", // Rotating circle lilac
+    pink: "#FFB6C1", // Rotating circle pink
+    "blue-dark": "#0054DB", // Rotating circle dark blue
   },
 };

--- a/src/design/colors.ts
+++ b/src/design/colors.ts
@@ -14,10 +14,14 @@ export const colors = {
   "blue-400": tailwindColors.blue[400], // Android settings tint
   "blue-500": tailwindColors.blue[500], // iOS settings tint
   pastel: {
-    orange: "#F2CAAD", // Home screen planet
+    orange: "#F2CAAD", // Home screen planet, rotating circle default
     gray: "#E1E3DC", // Home screen planet
     green: "#ECE9B7", // Home screen planet
     "orange-light": "#F1E0D9", // Home screen button
     "gray-light": "#E7E9E6", // Home screen button
+    "blue-light": "#ADD8E6", // Rotating circle blue
+    lilac: "#D8B9FF", // Rotating circle lilac
+    pink: "#FFB6C1", // Rotating circle pink
+    "blue-dark": "#0054DB", // Rotating circle dark blue
   },
 };

--- a/src/screens/exercise-screen/breathing-animation.tsx
+++ b/src/screens/exercise-screen/breathing-animation.tsx
@@ -4,6 +4,7 @@ import React, { FC, useEffect, useRef } from "react";
 import { Animated, View } from "react-native";
 import { colors } from "@breathly/design/colors";
 import { shortestDeviceDimension } from "@breathly/design/metrics";
+import { useSettingsStore } from "@breathly/stores/settings";
 import { animate } from "@breathly/utils/animate";
 import { times } from "@breathly/utils/times";
 
@@ -15,8 +16,11 @@ interface Props {
   color?: string;
 }
 
-export const BreathingAnimation: FC<Props> = ({ animationValue, color = colors.pastel.orange }) => {
+export const BreathingAnimation: FC<Props> = ({ animationValue, color }) => {
   const { colorScheme } = useColorScheme();
+  const { customBreathingShapeColor } = useSettingsStore();
+  const { breathingShapeColor } = useSettingsStore();
+  color = customBreathingShapeColor ? colors.pastel[breathingShapeColor] : colors.pastel.orange;
   const mountAnimationValue = useRef(new Animated.Value(0)).current;
   const innerOpacity = animationValue.interpolate({
     inputRange: [0, 0.1, 1],

--- a/src/screens/exercise-screen/breathing-animation.tsx
+++ b/src/screens/exercise-screen/breathing-animation.tsx
@@ -2,7 +2,6 @@ import setColor from "color";
 import { useColorScheme } from "nativewind";
 import React, { FC, useEffect, useRef } from "react";
 import { Animated, View } from "react-native";
-import { colors } from "@breathly/design/colors";
 import { shortestDeviceDimension } from "@breathly/design/metrics";
 import { useSettingsStore } from "@breathly/stores/settings";
 import { animate } from "@breathly/utils/animate";
@@ -13,14 +12,11 @@ const MOUNT_ANIMATION_DURATION = 300;
 
 interface Props {
   animationValue: Animated.Value;
-  color?: string;
+  color: string;
 }
 
 export const BreathingAnimation: FC<Props> = ({ animationValue, color }) => {
   const { colorScheme } = useColorScheme();
-  const { customRotatingCircleColor } = useSettingsStore();
-  const { rotatingCircleColor } = useSettingsStore();
-  color = customRotatingCircleColor ? colors.pastel[rotatingCircleColor] : colors.pastel.orange;
   const mountAnimationValue = useRef(new Animated.Value(0)).current;
   const innerOpacity = animationValue.interpolate({
     inputRange: [0, 0.1, 1],

--- a/src/screens/exercise-screen/breathing-animation.tsx
+++ b/src/screens/exercise-screen/breathing-animation.tsx
@@ -4,6 +4,7 @@ import React, { FC, useEffect, useRef } from "react";
 import { Animated, View } from "react-native";
 import { colors } from "@breathly/design/colors";
 import { shortestDeviceDimension } from "@breathly/design/metrics";
+import { useSettingsStore } from "@breathly/stores/settings";
 import { animate } from "@breathly/utils/animate";
 import { times } from "@breathly/utils/times";
 
@@ -15,8 +16,11 @@ interface Props {
   color?: string;
 }
 
-export const BreathingAnimation: FC<Props> = ({ animationValue, color = colors.pastel.orange }) => {
+export const BreathingAnimation: FC<Props> = ({ animationValue, color }) => {
   const { colorScheme } = useColorScheme();
+  const { customRotatingCircleColor } = useSettingsStore();
+  const { rotatingCircleColor } = useSettingsStore();
+  color = customRotatingCircleColor ? colors.pastel[rotatingCircleColor] : colors.pastel.orange;
   const mountAnimationValue = useRef(new Animated.Value(0)).current;
   const innerOpacity = animationValue.interpolate({
     inputRange: [0, 0.1, 1],

--- a/src/screens/exercise-screen/breathing-animation.tsx
+++ b/src/screens/exercise-screen/breathing-animation.tsx
@@ -18,9 +18,9 @@ interface Props {
 
 export const BreathingAnimation: FC<Props> = ({ animationValue, color }) => {
   const { colorScheme } = useColorScheme();
-  const { customBreathingShapeColor } = useSettingsStore();
-  const { breathingShapeColor } = useSettingsStore();
-  color = customBreathingShapeColor ? colors.pastel[breathingShapeColor] : colors.pastel.orange;
+  const { customRotatingCircleColor } = useSettingsStore();
+  const { rotatingCircleColor } = useSettingsStore();
+  color = customRotatingCircleColor ? colors.pastel[rotatingCircleColor] : colors.pastel.orange;
   const mountAnimationValue = useRef(new Animated.Value(0)).current;
   const innerOpacity = animationValue.interpolate({
     inputRange: [0, 0.1, 1],

--- a/src/screens/exercise-screen/exercise-screen.tsx
+++ b/src/screens/exercise-screen/exercise-screen.tsx
@@ -7,6 +7,7 @@ import { Animated, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Pressable } from "@breathly/common/pressable";
 import { RootStackParamList } from "@breathly/core/navigator";
+import { colors } from "@breathly/design/colors";
 import { widestDeviceDimension } from "@breathly/design/metrics";
 import { AnimatedDots } from "@breathly/screens/exercise-screen/animated-dots";
 import { StepDescription } from "@breathly/screens/exercise-screen/step-description";
@@ -103,6 +104,11 @@ const ExerciseRunningFragment: FC<ExerciseRunningFragmentProps> = ({
   const selectedPatternSteps = useSelectedPatternSteps();
   const [unmountContentAnimVal] = useState(new Animated.Value(1));
   const stepsMetadata = buildStepsMetadata(selectedPatternSteps);
+  const { rotatingCircleColorEnabled } = useSettingsStore();
+  const { rotatingCircleColor } = useSettingsStore();
+  const color = rotatingCircleColorEnabled
+    ? colors.pastel[rotatingCircleColor]
+    : colors.pastel.orange;
 
   const { currentStep, exerciseAnimVal, textAnimVal } = useExerciseLoop(stepsMetadata);
 
@@ -140,7 +146,7 @@ const ExerciseRunningFragment: FC<ExerciseRunningFragmentProps> = ({
       <Timer limit={timeLimit} onLimitReached={handleTimeLimitReached} />
       {currentStep && (
         <View className="flex-1 items-center justify-center">
-          <BreathingAnimation animationValue={exerciseAnimVal} />
+          <BreathingAnimation animationValue={exerciseAnimVal} color={color} />
           <StepDescription label={currentStep.label} animationValue={textAnimVal} />
           <AnimatedDots
             numberOfDots={3}

--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -48,9 +48,9 @@ export const SettingsRootScreen: FC<
   const setTheme = useSettingsStore((state) => state.setTheme);
   const vibrationEnabled = useSettingsStore((state) => state.vibrationEnabled);
   const setVibrationEnabled = useSettingsStore((state) => state.setVibrationEnabled);
-  const customRotatingCircleColor = useSettingsStore((state) => state.customRotatingCircleColor);
-  const setCustomRotatingCircleColor = useSettingsStore(
-    (state) => state.setCustomRotatingCircleColor
+  const rotatingCircleColorEnabled = useSettingsStore((state) => state.rotatingCircleColorEnabled);
+  const setrotatingCircleColorEnabled = useSettingsStore(
+    (state) => state.setrotatingCircleColorEnabled
   );
   const rotatingCircleColor = useSettingsStore((state) => state.rotatingCircleColor);
   const setRotatingCircleColor = useSettingsStore((state) => state.setRotatingCircleColor);
@@ -129,10 +129,10 @@ export const SettingsRootScreen: FC<
               secondaryLabel="Change rotating circle color"
               iconName="ios-moon"
               iconBackgroundColor="#a5b4fc"
-              value={customRotatingCircleColor}
-              onValueChange={setCustomRotatingCircleColor}
+              value={rotatingCircleColorEnabled}
+              onValueChange={setrotatingCircleColorEnabled}
             />
-            {customRotatingCircleColor && (
+            {rotatingCircleColorEnabled && (
               <View style={{ flexDirection: "column" }}>
                 <View
                   style={{

--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -39,12 +39,12 @@ export const SettingsRootScreen: FC<
   const setTheme = useSettingsStore((state) => state.setTheme);
   const vibrationEnabled = useSettingsStore((state) => state.vibrationEnabled);
   const setVibrationEnabled = useSettingsStore((state) => state.setVibrationEnabled);
-  const customBreathingShapeColor = useSettingsStore((state) => state.customBreathingShapeColor);
-  const setCustomBreathingShapeColor = useSettingsStore(
-    (state) => state.setCustomBreathingShapeColor
+  const customRotatingCircleColor = useSettingsStore((state) => state.customRotatingCircleColor);
+  const setCustomRotatingCircleColor = useSettingsStore(
+    (state) => state.setCustomRotatingCircleColor
   );
-  const breathingShapeColor = useSettingsStore((state) => state.breathingShapeColor);
-  const setBreathingShapeColor = useSettingsStore((state) => state.setBreathingShapeColor);
+  const rotatingCircleColor = useSettingsStore((state) => state.rotatingCircleColor);
+  const setRotatingCircleColor = useSettingsStore((state) => state.setRotatingCircleColor);
 
   React.useEffect(() => {
     // Use `setOptions` to update the button that we previously specified
@@ -116,16 +116,16 @@ export const SettingsRootScreen: FC<
               />
             )}
             <SettingsUI.SwitchItem
-              label="Custom breathing shape color"
-              secondaryLabel="Change breathing shape color"
+              label="Custom rotating circle color"
+              secondaryLabel="Change rotating circle color"
               iconName="ios-moon"
               iconBackgroundColor="#a5b4fc"
-              value={customBreathingShapeColor}
-              onValueChange={setCustomBreathingShapeColor}
+              value={customRotatingCircleColor}
+              onValueChange={setCustomRotatingCircleColor}
             />
-            {customBreathingShapeColor && (
+            {customRotatingCircleColor && (
               <SettingsUI.PickerItem
-                label="Breathing shape color"
+                label="Rotating circle color"
                 iconName="ios-color-palette"
                 iconBackgroundColor="#d8b4fe"
                 options={[
@@ -134,8 +134,8 @@ export const SettingsRootScreen: FC<
                   { value: "pink", label: "Pink" },
                   { value: "blue-dark", label: "Dark blue" },
                 ]}
-                value={breathingShapeColor}
-                onValueChange={setBreathingShapeColor}
+                value={rotatingCircleColor}
+                onValueChange={setRotatingCircleColor}
               />
             )}
           </SettingsUI.Section>

--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -1,18 +1,9 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import ms from "ms";
 import React, { FC } from "react";
-import {
-  Animated,
-  ScrollView,
-  LayoutAnimation,
-  Button,
-  Platform,
-  View,
-  StyleSheet,
-} from "react-native";
+import { Animated, ScrollView, LayoutAnimation, Button, Platform } from "react-native";
 import { patternPresets } from "@breathly/assets/pattern-presets";
 import { SettingsStackParamList } from "@breathly/core/navigator";
-import { colors } from "@breathly/design/colors";
 import { SettingsUI } from "@breathly/screens/settings-screen/settings-ui";
 import {
   useSelectedPatternSteps,
@@ -133,29 +124,19 @@ export const SettingsRootScreen: FC<
               onValueChange={setRotatingCircleColorEnabled}
             />
             {rotatingCircleColorEnabled && (
-              <View style={{ flexDirection: "column" }}>
-                <View
-                  style={{
-                    width: 25,
-                    height: 25,
-                    backgroundColor: colors.pastel[rotatingCircleColor],
-                    marginLeft: 23,
-                  }}
-                />
-                <SettingsUI.PickerItem
-                  label="Rotating circle color"
-                  iconName="ios-color-palette"
-                  iconBackgroundColor="#d8b4fe"
-                  options={[
-                    { value: "blue-light", label: "Light blue" },
-                    { value: "lilac", label: "Lilac" },
-                    { value: "pink", label: "Pink" },
-                    { value: "blue-dark", label: "Dark blue" },
-                  ]}
-                  value={rotatingCircleColor}
-                  onValueChange={setRotatingCircleColor}
-                />
-              </View>
+              <SettingsUI.PickerItem
+                label="Rotating circle color"
+                iconName="ios-color-palette"
+                iconBackgroundColor="#d8b4fe"
+                options={[
+                  { value: "blue-light", label: "Light blue" },
+                  { value: "lilac", label: "Lilac" },
+                  { value: "pink", label: "Pink" },
+                  { value: "blue-dark", label: "Dark blue" },
+                ]}
+                value={rotatingCircleColor}
+                onValueChange={setRotatingCircleColor}
+              />
             )}
           </SettingsUI.Section>
           <SettingsUI.Section label="Haptics">

--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -1,9 +1,18 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import ms from "ms";
 import React, { FC } from "react";
-import { Animated, ScrollView, LayoutAnimation, Button, Platform } from "react-native";
+import {
+  Animated,
+  ScrollView,
+  LayoutAnimation,
+  Button,
+  Platform,
+  View,
+  StyleSheet,
+} from "react-native";
 import { patternPresets } from "@breathly/assets/pattern-presets";
 import { SettingsStackParamList } from "@breathly/core/navigator";
+import { colors } from "@breathly/design/colors";
 import { SettingsUI } from "@breathly/screens/settings-screen/settings-ui";
 import {
   useSelectedPatternSteps,
@@ -39,6 +48,12 @@ export const SettingsRootScreen: FC<
   const setTheme = useSettingsStore((state) => state.setTheme);
   const vibrationEnabled = useSettingsStore((state) => state.vibrationEnabled);
   const setVibrationEnabled = useSettingsStore((state) => state.setVibrationEnabled);
+  const customRotatingCircleColor = useSettingsStore((state) => state.customRotatingCircleColor);
+  const setCustomRotatingCircleColor = useSettingsStore(
+    (state) => state.setCustomRotatingCircleColor
+  );
+  const rotatingCircleColor = useSettingsStore((state) => state.rotatingCircleColor);
+  const setRotatingCircleColor = useSettingsStore((state) => state.setRotatingCircleColor);
 
   React.useEffect(() => {
     // Use `setOptions` to update the button that we previously specified
@@ -108,6 +123,39 @@ export const SettingsRootScreen: FC<
                 value={theme}
                 onValueChange={setTheme}
               />
+            )}
+            <SettingsUI.SwitchItem
+              label="Custom rotating circle color"
+              secondaryLabel="Change rotating circle color"
+              iconName="ios-moon"
+              iconBackgroundColor="#a5b4fc"
+              value={customRotatingCircleColor}
+              onValueChange={setCustomRotatingCircleColor}
+            />
+            {customRotatingCircleColor && (
+              <View style={{ flexDirection: "column" }}>
+                <View
+                  style={{
+                    width: 25,
+                    height: 25,
+                    backgroundColor: colors.pastel[rotatingCircleColor],
+                    marginLeft: 23,
+                  }}
+                />
+                <SettingsUI.PickerItem
+                  label="Rotating circle color"
+                  iconName="ios-color-palette"
+                  iconBackgroundColor="#d8b4fe"
+                  options={[
+                    { value: "blue-light", label: "Light blue" },
+                    { value: "lilac", label: "Lilac" },
+                    { value: "pink", label: "Pink" },
+                    { value: "blue-dark", label: "Dark blue" },
+                  ]}
+                  value={rotatingCircleColor}
+                  onValueChange={setRotatingCircleColor}
+                />
+              </View>
             )}
           </SettingsUI.Section>
           <SettingsUI.Section label="Haptics">

--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -1,9 +1,18 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import ms from "ms";
 import React, { FC } from "react";
-import { Animated, ScrollView, LayoutAnimation, Button, Platform } from "react-native";
+import {
+  Animated,
+  ScrollView,
+  LayoutAnimation,
+  Button,
+  Platform,
+  View,
+  StyleSheet,
+} from "react-native";
 import { patternPresets } from "@breathly/assets/pattern-presets";
 import { SettingsStackParamList } from "@breathly/core/navigator";
+import { colors } from "@breathly/design/colors";
 import { SettingsUI } from "@breathly/screens/settings-screen/settings-ui";
 import {
   useSelectedPatternSteps,
@@ -124,19 +133,29 @@ export const SettingsRootScreen: FC<
               onValueChange={setCustomRotatingCircleColor}
             />
             {customRotatingCircleColor && (
-              <SettingsUI.PickerItem
-                label="Rotating circle color"
-                iconName="ios-color-palette"
-                iconBackgroundColor="#d8b4fe"
-                options={[
-                  { value: "blue-light", label: "Light blue" },
-                  { value: "lilac", label: "Lilac" },
-                  { value: "pink", label: "Pink" },
-                  { value: "blue-dark", label: "Dark blue" },
-                ]}
-                value={rotatingCircleColor}
-                onValueChange={setRotatingCircleColor}
-              />
+              <View style={{ flexDirection: "column" }}>
+                <View
+                  style={{
+                    width: 25,
+                    height: 25,
+                    backgroundColor: colors.pastel[rotatingCircleColor],
+                    marginLeft: 23,
+                  }}
+                />
+                <SettingsUI.PickerItem
+                  label="Rotating circle color"
+                  iconName="ios-color-palette"
+                  iconBackgroundColor="#d8b4fe"
+                  options={[
+                    { value: "blue-light", label: "Light blue" },
+                    { value: "lilac", label: "Lilac" },
+                    { value: "pink", label: "Pink" },
+                    { value: "blue-dark", label: "Dark blue" },
+                  ]}
+                  value={rotatingCircleColor}
+                  onValueChange={setRotatingCircleColor}
+                />
+              </View>
             )}
           </SettingsUI.Section>
           <SettingsUI.Section label="Haptics">

--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -49,8 +49,8 @@ export const SettingsRootScreen: FC<
   const vibrationEnabled = useSettingsStore((state) => state.vibrationEnabled);
   const setVibrationEnabled = useSettingsStore((state) => state.setVibrationEnabled);
   const rotatingCircleColorEnabled = useSettingsStore((state) => state.rotatingCircleColorEnabled);
-  const setrotatingCircleColorEnabled = useSettingsStore(
-    (state) => state.setrotatingCircleColorEnabled
+  const setRotatingCircleColorEnabled = useSettingsStore(
+    (state) => state.setRotatingCircleColorEnabled
   );
   const rotatingCircleColor = useSettingsStore((state) => state.rotatingCircleColor);
   const setRotatingCircleColor = useSettingsStore((state) => state.setRotatingCircleColor);
@@ -130,7 +130,7 @@ export const SettingsRootScreen: FC<
               iconName="ios-moon"
               iconBackgroundColor="#a5b4fc"
               value={rotatingCircleColorEnabled}
-              onValueChange={setrotatingCircleColorEnabled}
+              onValueChange={setRotatingCircleColorEnabled}
             />
             {rotatingCircleColorEnabled && (
               <View style={{ flexDirection: "column" }}>

--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -129,10 +129,10 @@ export const SettingsRootScreen: FC<
                 iconName="ios-color-palette-outline"
                 iconBackgroundColor="#03a5fc"
                 options={[
-                  { value: "blue-light", label: "Light Blue" },
+                  { value: "blue-light", label: "Light blue" },
                   { value: "lilac", label: "Lilac" },
                   { value: "pink", label: "Pink" },
-                  { value: "blue-dark", label: "Dark Blue" },
+                  { value: "blue-dark", label: "Dark blue" },
                 ]}
                 value={rotatingCircleColor}
                 onValueChange={setRotatingCircleColor}

--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -39,6 +39,12 @@ export const SettingsRootScreen: FC<
   const setTheme = useSettingsStore((state) => state.setTheme);
   const vibrationEnabled = useSettingsStore((state) => state.vibrationEnabled);
   const setVibrationEnabled = useSettingsStore((state) => state.setVibrationEnabled);
+  const customBreathingShapeColor = useSettingsStore((state) => state.customBreathingShapeColor);
+  const setCustomBreathingShapeColor = useSettingsStore(
+    (state) => state.setCustomBreathingShapeColor
+  );
+  const breathingShapeColor = useSettingsStore((state) => state.breathingShapeColor);
+  const setBreathingShapeColor = useSettingsStore((state) => state.setBreathingShapeColor);
 
   React.useEffect(() => {
     // Use `setOptions` to update the button that we previously specified
@@ -107,6 +113,29 @@ export const SettingsRootScreen: FC<
                 ]}
                 value={theme}
                 onValueChange={setTheme}
+              />
+            )}
+            <SettingsUI.SwitchItem
+              label="Custom breathing shape color"
+              secondaryLabel="Change breathing shape color"
+              iconName="ios-moon"
+              iconBackgroundColor="#a5b4fc"
+              value={customBreathingShapeColor}
+              onValueChange={setCustomBreathingShapeColor}
+            />
+            {customBreathingShapeColor && (
+              <SettingsUI.PickerItem
+                label="Breathing shape color"
+                iconName="ios-color-palette"
+                iconBackgroundColor="#d8b4fe"
+                options={[
+                  { value: "blue-light", label: "Light blue" },
+                  { value: "lilac", label: "Lilac" },
+                  { value: "pink", label: "Pink" },
+                  { value: "blue-dark", label: "Dark blue" },
+                ]}
+                value={breathingShapeColor}
+                onValueChange={setBreathingShapeColor}
               />
             )}
           </SettingsUI.Section>

--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -118,21 +118,21 @@ export const SettingsRootScreen: FC<
             <SettingsUI.SwitchItem
               label="Custom rotating circle color"
               secondaryLabel="Change rotating circle color"
-              iconName="ios-moon"
-              iconBackgroundColor="#a5b4fc"
+              iconName="ios-color-filter"
+              iconBackgroundColor="#f2cddc"
               value={rotatingCircleColorEnabled}
               onValueChange={setRotatingCircleColorEnabled}
             />
             {rotatingCircleColorEnabled && (
               <SettingsUI.PickerItem
                 label="Rotating circle color"
-                iconName="ios-color-palette"
-                iconBackgroundColor="#d8b4fe"
+                iconName="ios-color-palette-outline"
+                iconBackgroundColor="#03a5fc"
                 options={[
-                  { value: "blue-light", label: "Light blue" },
+                  { value: "blue-light", label: "Light Blue" },
                   { value: "lilac", label: "Lilac" },
                   { value: "pink", label: "Pink" },
-                  { value: "blue-dark", label: "Dark blue" },
+                  { value: "blue-dark", label: "Dark Blue" },
                 ]}
                 value={rotatingCircleColor}
                 onValueChange={setRotatingCircleColor}

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -24,6 +24,12 @@ interface SettingsStore {
   setTheme: (theme: "dark" | "light") => unknown;
   vibrationEnabled: boolean;
   setVibrationEnabled: (vibrationEnabled: boolean) => unknown;
+  customRotatingCircleColor: boolean;
+  setCustomRotatingCircleColor: (customRotatingCircleColor: boolean) => unknown;
+  rotatingCircleColor: "blue-light" | "lilac" | "pink" | "blue-dark";
+  setRotatingCircleColor: (
+    rotatingCircleColor: "blue-light" | "lilac" | "pink" | "blue-dark"
+  ) => unknown;
 }
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -57,6 +63,11 @@ export const useSettingsStore = create<SettingsStore>()(
         setTheme: (theme) => set({ theme }),
         vibrationEnabled: true,
         setVibrationEnabled: (vibrationEnabled) => set({ vibrationEnabled }),
+        customRotatingCircleColor: false,
+        setCustomRotatingCircleColor: (customRotatingCircleColor) =>
+          set({ customRotatingCircleColor }),
+        rotatingCircleColor: "blue-light",
+        setRotatingCircleColor: (rotatingCircleColor) => set({ rotatingCircleColor }),
       }),
       {
         name: "settings-storage",

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -24,11 +24,11 @@ interface SettingsStore {
   setTheme: (theme: "dark" | "light") => unknown;
   vibrationEnabled: boolean;
   setVibrationEnabled: (vibrationEnabled: boolean) => unknown;
-  customBreathingShapeColor: boolean;
-  setCustomBreathingShapeColor: (darkerCircle: boolean) => unknown;
-  breathingShapeColor: "blue-light" | "lilac" | "pink" | "blue-dark";
-  setBreathingShapeColor: (
-    breathingShapeColor: "blue-light" | "lilac" | "pink" | "blue-dark"
+  customRotatingCircleColor: boolean;
+  setCustomRotatingCircleColor: (customRotatingCircleColor: boolean) => unknown;
+  rotatingCircleColor: "blue-light" | "lilac" | "pink" | "blue-dark";
+  setRotatingCircleColor: (
+    rotatingCircleColor: "blue-light" | "lilac" | "pink" | "blue-dark"
   ) => unknown;
 }
 
@@ -63,11 +63,11 @@ export const useSettingsStore = create<SettingsStore>()(
         setTheme: (theme) => set({ theme }),
         vibrationEnabled: true,
         setVibrationEnabled: (vibrationEnabled) => set({ vibrationEnabled }),
-        customBreathingShapeColor: false,
-        setCustomBreathingShapeColor: (customBreathingShapeColor) =>
-          set({ customBreathingShapeColor }),
-        breathingShapeColor: "blue-light",
-        setBreathingShapeColor: (breathingShapeColor) => set({ breathingShapeColor }),
+        customRotatingCircleColor: false,
+        setCustomRotatingCircleColor: (customRotatingCircleColor) =>
+          set({ customRotatingCircleColor }),
+        rotatingCircleColor: "blue-light",
+        setRotatingCircleColor: (rotatingCircleColor) => set({ rotatingCircleColor }),
       }),
       {
         name: "settings-storage",

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -24,6 +24,12 @@ interface SettingsStore {
   setTheme: (theme: "dark" | "light") => unknown;
   vibrationEnabled: boolean;
   setVibrationEnabled: (vibrationEnabled: boolean) => unknown;
+  customBreathingShapeColor: boolean;
+  setCustomBreathingShapeColor: (darkerCircle: boolean) => unknown;
+  breathingShapeColor: "blue-light" | "lilac" | "pink" | "blue-dark";
+  setBreathingShapeColor: (
+    breathingShapeColor: "blue-light" | "lilac" | "pink" | "blue-dark"
+  ) => unknown;
 }
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -57,6 +63,11 @@ export const useSettingsStore = create<SettingsStore>()(
         setTheme: (theme) => set({ theme }),
         vibrationEnabled: true,
         setVibrationEnabled: (vibrationEnabled) => set({ vibrationEnabled }),
+        customBreathingShapeColor: false,
+        setCustomBreathingShapeColor: (customBreathingShapeColor) =>
+          set({ customBreathingShapeColor }),
+        breathingShapeColor: "blue-light",
+        setBreathingShapeColor: (breathingShapeColor) => set({ breathingShapeColor }),
       }),
       {
         name: "settings-storage",

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -24,8 +24,8 @@ interface SettingsStore {
   setTheme: (theme: "dark" | "light") => unknown;
   vibrationEnabled: boolean;
   setVibrationEnabled: (vibrationEnabled: boolean) => unknown;
-  customRotatingCircleColor: boolean;
-  setCustomRotatingCircleColor: (customRotatingCircleColor: boolean) => unknown;
+  rotatingCircleColorEnabled: boolean;
+  setrotatingCircleColorEnabled: (rotatingCircleColorEnabled: boolean) => unknown;
   rotatingCircleColor: "blue-light" | "lilac" | "pink" | "blue-dark";
   setRotatingCircleColor: (
     rotatingCircleColor: "blue-light" | "lilac" | "pink" | "blue-dark"
@@ -63,9 +63,9 @@ export const useSettingsStore = create<SettingsStore>()(
         setTheme: (theme) => set({ theme }),
         vibrationEnabled: true,
         setVibrationEnabled: (vibrationEnabled) => set({ vibrationEnabled }),
-        customRotatingCircleColor: false,
-        setCustomRotatingCircleColor: (customRotatingCircleColor) =>
-          set({ customRotatingCircleColor }),
+        rotatingCircleColorEnabled: false,
+        setrotatingCircleColorEnabled: (rotatingCircleColorEnabled) =>
+          set({ rotatingCircleColorEnabled }),
         rotatingCircleColor: "blue-light",
         setRotatingCircleColor: (rotatingCircleColor) => set({ rotatingCircleColor }),
       }),

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -25,7 +25,7 @@ interface SettingsStore {
   vibrationEnabled: boolean;
   setVibrationEnabled: (vibrationEnabled: boolean) => unknown;
   rotatingCircleColorEnabled: boolean;
-  setrotatingCircleColorEnabled: (rotatingCircleColorEnabled: boolean) => unknown;
+  setRotatingCircleColorEnabled: (rotatingCircleColorEnabled: boolean) => unknown;
   rotatingCircleColor: "blue-light" | "lilac" | "pink" | "blue-dark";
   setRotatingCircleColor: (
     rotatingCircleColor: "blue-light" | "lilac" | "pink" | "blue-dark"
@@ -64,7 +64,7 @@ export const useSettingsStore = create<SettingsStore>()(
         vibrationEnabled: true,
         setVibrationEnabled: (vibrationEnabled) => set({ vibrationEnabled }),
         rotatingCircleColorEnabled: false,
-        setrotatingCircleColorEnabled: (rotatingCircleColorEnabled) =>
+        setRotatingCircleColorEnabled: (rotatingCircleColorEnabled) =>
           set({ rotatingCircleColorEnabled }),
         rotatingCircleColor: "blue-light",
         setRotatingCircleColor: (rotatingCircleColor) => set({ rotatingCircleColor }),


### PR DESCRIPTION
Added light blue, lilac, pink, and dark blue color options for the rotating circle in settings.
Added preview for the currently selected color option in settings.
Changes made based on issue #118. Dark blue contrasts much more with the light theme's background than the default color.
Dark blue:
![image](https://github.com/mmazzarolo/breathly-app/assets/134813127/01033ea6-bf37-4663-ace1-f8cefc15aad3)
Original:
![image](https://github.com/mmazzarolo/breathly-app/assets/134813127/5061a420-ea84-483a-9c1b-4f76a005e08b)
New settings screen:
![image](https://github.com/mmazzarolo/breathly-app/assets/134813127/da66e7ae-1693-455a-83d7-addf84a3505f)