### PR TITLE
Added repetition stepper to settings and changed time stepper to accommodate repetitions in settings

### DIFF
--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -143,7 +143,12 @@ export const SettingsRootScreen: FC<
               label="Exercise repetitions"
               secondaryLabel="# of repetitions"
               value={repetitions > 0 ? repetitions : "∞"}
-              fractionDigits={Math.min(2, 3-Math.floor(Math.log10(repetitions)))}
+              fractionDigits={
+                // 0-100: 2 decimal points
+                // 100-1000: 1 decimal point
+                // 1000+: no decimal
+                Math.min(2, 3-Math.floor(Math.log10(repetitions)))
+              }
               iconName="ios-timer"
               iconBackgroundColor="#7195fa"
               onIncrease={increaseRepetitions}

--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -31,6 +31,10 @@ export const SettingsRootScreen: FC<
   const timeLimit = useSettingsStore((state) => state.timeLimit);
   const increaseTimeLimit = useSettingsStore((state) => state.increaseTimeLimit);
   const decreaseTimeLimit = useSettingsStore((state) => state.decreaseTimeLimit);
+  const repetitions = useSettingsStore((state) => state.repetitions);
+  const timeStep = useSettingsStore((state) => state.timeStep);
+  const increaseRepetitions = useSettingsStore((state) => state.increaseRepetitions);
+  const decreaseRepetitions = useSettingsStore((state) => state.decreaseRepetitions);
   const shouldFollowSystemDarkMode = useSettingsStore((state) => state.shouldFollowSystemDarkMode);
   const setShouldFollowSystemDarkMode = useSettingsStore(
     (state) => state.setShouldFollowSystemDarkMode
@@ -123,7 +127,7 @@ export const SettingsRootScreen: FC<
           <SettingsUI.Section label="Timer" hideBottomBorderAndroid>
             <SettingsUI.StepperItem
               label="Exercise timer"
-              secondaryLabel="Time limit in minutes"
+              secondaryLabel="Time limit"
               value={timeLimit > 0 ? timeLimit / ms("1 min") : "∞"}
               iconName="ios-timer"
               iconBackgroundColor="#fb7185"
@@ -131,6 +135,22 @@ export const SettingsRootScreen: FC<
               onDecrease={decreaseTimeLimit}
               decreaseDisabled={timeLimit <= 0}
               increaseDisabled={timeLimit >= maxTimeLimit}
+              formatAsTime={true}
+            />
+          </SettingsUI.Section>
+          <SettingsUI.Section label="Repetitions" hideBottomBorderAndroid>
+            <SettingsUI.StepperItem
+              label="Exercise repetitions"
+              secondaryLabel="# of repetitions"
+              value={repetitions > 0 ? repetitions : "∞"}
+              fractionDigits={Math.min(2, 3-Math.floor(Math.log10(repetitions)))}
+              iconName="ios-timer"
+              iconBackgroundColor="#7195fa"
+              onIncrease={increaseRepetitions}
+              onDecrease={decreaseRepetitions}
+              decreaseDisabled={repetitions <= 0}
+              increaseDisabled={repetitions >= Math.floor(maxTimeLimit / timeStep)}
+              formatAsTime={false}
             />
           </SettingsUI.Section>
         </ScrollView>

--- a/src/screens/settings-screen/settings-ui.android.tsx
+++ b/src/screens/settings-screen/settings-ui.android.tsx
@@ -13,6 +13,7 @@ import {
   SwitchItemProps,
   SectionProps,
 } from "./settings-ui";
+import { formatValue } from "@breathly/utils/format-stepper-value"
 
 const Section: React.FC<PropsWithChildren<SectionProps>> = ({
   label,
@@ -169,6 +170,7 @@ const StepperItem: FC<StepperItemProps> = ({
   decreaseDisabled,
   onIncrease,
   onDecrease,
+  formatAsTime,
   fractionDigits,
   ...baseProps
 }) => {
@@ -184,14 +186,12 @@ const StepperItem: FC<StepperItemProps> = ({
         >
           <MaterialCommunityIcons name="minus" size={16} color="white" />
         </Pressable>
-        <View className={`${fractionDigits > 0 ? "w-14" : "w-8"} self-center px-2`}>
+        <View className={`w-14 self-center px-2`}>
           <Text
             className="text-center font-breathly-mono font-semibold dark:text-white"
             numberOfLines={1}
           >
-            {typeof value === "number" && fractionDigits > 0
-              ? value.toFixed(fractionDigits)
-              : value}
+            {formatValue(value, formatAsTime, fractionDigits)}
           </Text>
         </View>
         <Pressable

--- a/src/screens/settings-screen/settings-ui.d.ts
+++ b/src/screens/settings-screen/settings-ui.d.ts
@@ -34,6 +34,7 @@ export interface StepperItemProps extends CommonItemProps {
   onIncrease?: () => unknown;
   onDecrease?: () => unknown;
   fractionDigits?: number;
+  formatAsTime?: boolean;
 }
 
 export interface RadioButtonItemProps extends CommonItemProps {

--- a/src/screens/settings-screen/settings-ui.ios.tsx
+++ b/src/screens/settings-screen/settings-ui.ios.tsx
@@ -13,6 +13,7 @@ import {
   SwitchItemProps,
   SectionProps,
 } from "./settings-ui";
+import { formatValue } from "@breathly/utils/format-stepper-value"
 
 const Section: React.FC<PropsWithChildren<SectionProps>> = ({ label, children }) => {
   return (
@@ -138,6 +139,7 @@ export const StepperItem: FC<StepperItemProps> = ({
   decreaseDisabled,
   onIncrease,
   onDecrease,
+  formatAsTime,
   fractionDigits,
   ...baseProps
 }) => {
@@ -158,15 +160,13 @@ export const StepperItem: FC<StepperItemProps> = ({
             color={colorScheme === "dark" ? "white" : colors["slate-500"]}
           />
         </Pressable>
-        <View className={`${fractionDigits > 0 ? "w-14" : "w-8"} self-center px-2`}>
+        <View className={`w-14 self-center px-2`}>
           <Text
             className="text-center font-breathly-mono dark:text-white"
             style={{ fontVariant: ["tabular-nums"] }}
             numberOfLines={1}
           >
-            {typeof value === "number" && fractionDigits > 0
-              ? value.toFixed(fractionDigits)
-              : value}
+            {formatValue(value, formatAsTime, fractionDigits)}
           </Text>
         </View>
         <Pressable

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -60,10 +60,14 @@ export const useSettingsStore = create<SettingsStore>()(
         setGuidedBreathingVoice: (guidedBreathingVoice) => set({ guidedBreathingVoice }),
         timeLimit: ms("2 min"),
         increaseTimeLimit: () => {
+          // If seconds, goes to next minute, otherwise adds 1 minute
+          // e.g. 4:56 --> 5:00 --> 6:00
           set({ timeLimit: Math.floor(get().timeLimit / ms("1 min"))*ms("1 min") + ms("1 min") })
           get().setRepetitions(get().timeLimit / get().timeStep)
         },
         decreaseTimeLimit: () => {
+          // If seconds, goes to prev minute, otherwise subtracts 1 minute
+          // e.g. 4:56 --> 4:00 --> 3:00
           set({ timeLimit: Math.ceil(get().timeLimit / ms("1 min"))*ms("1 min") - ms("1 min") })
           get().setRepetitions(get().timeLimit / get().timeStep)
         },

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -18,6 +18,13 @@ interface SettingsStore {
   timeLimit: number;
   increaseTimeLimit: () => unknown;
   decreaseTimeLimit: () => unknown;
+  setTimeLimit: (timeLimit: number) => unknown;
+  repetitions: number;
+  increaseRepetitions: () => unknown;
+  decreaseRepetitions: () => unknown;
+  setRepetitions: (repetitions: number) => unknown;
+  timeStep: number;
+  setTimeStep: (stepValue: number) => unknown;
   shouldFollowSystemDarkMode: boolean;
   setShouldFollowSystemDarkMode: (shouldFollowSystemDarkMode: boolean) => unknown;
   theme: "dark" | "light";
@@ -42,14 +49,47 @@ export const useSettingsStore = create<SettingsStore>()(
           ];
           customPatternSteps[stepIndex] = stepValue;
           set({ customPatternSteps });
+          get().setTimeStep(get().timeStep)
         },
         selectedPatternPresetId: "square",
-        setSelectedPatternPresetId: (selectedPatternPresetId) => set({ selectedPatternPresetId }),
+        setSelectedPatternPresetId: (selectedPatternPresetId) => {
+          set({ selectedPatternPresetId })
+          get().setTimeStep(get().timeStep)
+        },
         guidedBreathingVoice: "paul",
         setGuidedBreathingVoice: (guidedBreathingVoice) => set({ guidedBreathingVoice }),
         timeLimit: ms("2 min"),
-        increaseTimeLimit: () => set({ timeLimit: get().timeLimit + ms("1 min") }),
-        decreaseTimeLimit: () => set({ timeLimit: get().timeLimit - ms("1 min") }),
+        increaseTimeLimit: () => {
+          set({ timeLimit: Math.floor(get().timeLimit / ms("1 min"))*ms("1 min") + ms("1 min") })
+          get().setRepetitions(get().timeLimit / get().timeStep)
+        },
+        decreaseTimeLimit: () => {
+          set({ timeLimit: Math.ceil(get().timeLimit / ms("1 min"))*ms("1 min") - ms("1 min") })
+          get().setRepetitions(get().timeLimit / get().timeStep)
+        },
+        setTimeLimit: (timeLimit) => set({ timeLimit }),
+        repetitions: 15,
+        increaseRepetitions: () => {
+          set({ repetitions: Math.floor(get().repetitions) + 1 })
+          get().setTimeLimit(get().repetitions * get().timeStep)
+        },
+        decreaseRepetitions: () => {
+          set({ repetitions: Math.ceil(get().repetitions) - 1 })
+          get().setTimeLimit(get().repetitions * get().timeStep)
+        },
+        setRepetitions: (repetitions) => set({ repetitions }),
+        timeStep: ms("16 sec"),
+        setTimeStep: (timeStep) => {
+          const steps = get().customPatternEnabled 
+            ? get().customPatternSteps
+            : patternPresets.find((patternPreset) => patternPreset.id === get().selectedPatternPresetId).steps
+          const arrSum = steps.reduce((accum, curVal) => {
+              return accum + curVal;
+          }, 0);
+          timeStep = arrSum;
+          set({ timeStep })
+          get().setRepetitions(get().timeLimit / get().timeStep)
+        },
         shouldFollowSystemDarkMode: true,
         setShouldFollowSystemDarkMode: (shouldFollowSystemDarkMode) =>
           set({ shouldFollowSystemDarkMode }),

--- a/src/utils/format-stepper-value.ts
+++ b/src/utils/format-stepper-value.ts
@@ -1,0 +1,15 @@
+import { formatTimer } from "@breathly/utils/format-timer"
+
+// Given a number of seconds returns them in a "timer" format (mm:ss).
+// E.g.: 120 -> 02:00
+export const formatValue = (value: unknown, formatAsTime: boolean, fractionDigits: number) => {
+    if (typeof value === "number") {
+        if (formatAsTime) {
+            if (value == 60) return '1h'
+            return formatTimer(Math.round(value*60));
+        } else {
+            return value.toFixed(fractionDigits);
+        }
+    }
+    return value;
+};

--- a/src/utils/format-stepper-value.ts
+++ b/src/utils/format-stepper-value.ts
@@ -1,7 +1,8 @@
 import { formatTimer } from "@breathly/utils/format-timer"
 
-// Given a number of seconds returns them in a "timer" format (mm:ss).
-// E.g.: 120 -> 02:00
+// If number is time, uses '1h' if it's 1:00:00 otherwise formatTime
+// If number is non-time nuemric value, rounds it to fractionDigits
+// Otherwise, return value itself (infinity)
 export const formatValue = (value: unknown, formatAsTime: boolean, fractionDigits: number) => {
     if (typeof value === "number") {
         if (formatAsTime) {


### PR DESCRIPTION
Summary of Changes:
- Added a new repetitions stepper to settings so that users can choose whether to end after a certain number of minutes or after a certain number of repetitions
- Changed time stepper to be in MM:SS format (or 1h to fit 01:00:00 without ellipsis)
   - Also made all steppers uniformly w-14
- Updates time stepper based on repetitions and vice versa

Here are demonstrations of what the new changes look like:
[IOS](https://youtu.be/WoMCN2Lf1Eo?si=-U1QbwG8Yf9_AYT0), [Android](https://youtu.be/wyBq1DG8el8?si=n4in8I0SnkLkJV7T)

Issues Fixed:
#125, #122 

Potential Bugs:
- Towards the end of IOS demonstration there is a bug where the app doesn't handle times ending in 0.5 correctly and will briefly show 59:59:5 before ending
- I tested on iPhone 16 Pro simulator and the Medium Phone Android API (1080x2400 display), so I haven't confirmed correctness on smaller phone sizes
