### PR TITLE
Prepare Breathly 2.2.0 store release

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Breathly",
     "slug": "breathly",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "orientation": "portrait",
     "icon": "./assets/ios-icon.png",
     "userInterfaceStyle": "automatic",
@@ -13,8 +13,11 @@
     "ios": {
       "supportsTablet": true,
       "icon": "./assets/ios-icon.png",
-      "buildNumber": "17",
-      "bundleIdentifier": "com.mmazzarolo.breathly"
+      "buildNumber": "18",
+      "bundleIdentifier": "com.mmazzarolo.breathly",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "blockedPermissions": [
@@ -31,7 +34,7 @@
       },
       "icon": "./assets/android-icon.png",
       "package": "com.mmazzarolo.breathly",
-      "versionCode": 3145747
+      "versionCode": 3145748
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/eas.json
+++ b/eas.json
@@ -15,6 +15,10 @@
   },
   "submit": {
     "production": {
+      "android": {
+        "track": "internal",
+        "releaseStatus": "completed"
+      },
       "ios": {
         "ascAppId": "1454852966"
       }


### PR DESCRIPTION
## Summary

- bump the public app version from 2.1.0 to 2.2.0
- bump the iOS build number from 17 to 18
- declare that the iOS app does not use non-exempt encryption
- bump the Android version code from 3145747 to 3145748
- configure EAS Submit to send Android production builds to the Google Play internal-testing track

## Release status

- iOS 2.2.0 (18) has been built and uploaded to App Store Connect/TestFlight
- Android 2.2.0 (3145748) has been built and submitted successfully to Google Play internal testing
- release tags `ios-2.2-(18)` and `android-2.2-(3145748)` point to this release commit
- neither platform has been released publicly

## Validation

- TypeScript typecheck passed
- ESLint passed
- Jest: 25 tests across 5 suites passed
- Expo Doctor: 21/21 checks passed
- production bundle exports passed for Android, iOS, and web
- EAS production builds completed successfully for iOS and Android
- store uploads completed successfully to TestFlight and Google Play internal testing

## Impact

This PR contains release metadata and submission configuration only; it does not change application behavior.
