### PR TITLE
Fix Android audio, launch splash, and home actions

### DIFF
--- a/app.json
+++ b/app.json
@@ -34,7 +34,7 @@
       },
       "icon": "./assets/android-icon.png",
       "package": "com.mmazzarolo.breathly",
-      "versionCode": 3145748
+      "versionCode": 3145749
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/app.json
+++ b/app.json
@@ -34,7 +34,7 @@
       },
       "icon": "./assets/android-icon.png",
       "package": "com.mmazzarolo.breathly",
-      "versionCode": 3145749
+      "versionCode": 3145750
     },
     "web": {
       "favicon": "./assets/favicon.png"
@@ -71,7 +71,12 @@
         {
           "image": "./assets/splash.png",
           "resizeMode": "cover",
-          "backgroundColor": "#F2F2F1"
+          "backgroundColor": "#F2F2F1",
+          "android": {
+            "drawable": {
+              "icon": "./assets/android-splash-screen-icon.xml"
+            }
+          }
         }
       ],
       "expo-asset"

--- a/assets/android-splash-screen-icon.xml
+++ b/assets/android-splash-screen-icon.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+  <solid android:color="@android:color/transparent" />
+</shape>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "color": "^4.2.3",
         "expo": "~56.0.15",
         "expo-asset": "~56.0.19",
-        "expo-audio": "~56.0.12",
+        "expo-audio": "~56.0.13",
         "expo-build-properties": "~56.0.22",
         "expo-dev-client": "~56.0.22",
         "expo-font": "~56.0.7",
@@ -34,7 +34,7 @@
         "react-dom": "19.2.3",
         "react-native": "0.85.3",
         "react-native-safe-area-context": "~5.7.0",
-        "react-native-screens": "4.25.2",
+        "react-native-screens": "~4.26.0",
         "react-native-web": "^0.21.2",
         "zustand": "^5.0.14"
       },
@@ -3778,87 +3778,6 @@
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
     },
-    "node_modules/@vue/compiler-core": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
-      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.45",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/compiler-dom": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
-      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vue/compiler-core": "3.2.45",
-        "@vue/shared": "3.2.45"
-      }
-    },
-    "node_modules/@vue/compiler-sfc": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
-      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.45",
-        "@vue/compiler-dom": "3.2.45",
-        "@vue/compiler-ssr": "3.2.45",
-        "@vue/reactivity-transform": "3.2.45",
-        "@vue/shared": "3.2.45",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7",
-        "postcss": "^8.1.10",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/compiler-ssr": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
-      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vue/compiler-dom": "3.2.45",
-        "@vue/shared": "3.2.45"
-      }
-    },
-    "node_modules/@vue/reactivity-transform": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
-      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.45",
-        "@vue/shared": "3.2.45",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7"
-      }
-    },
-    "node_modules/@vue/shared": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
-      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -6087,14 +6006,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6276,9 +6187,9 @@
       }
     },
     "node_modules/expo-audio": {
-      "version": "56.0.12",
-      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-56.0.12.tgz",
-      "integrity": "sha512-ne2UIO/HsQoBL9e+tGs5N9Sf3NyW5sJMm4sDkexbSJRc2IchLDG+9Msu/+l5N4RlZ8SiF42wRyWsh/Usg+SwOw==",
+      "version": "56.0.13",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-56.0.13.tgz",
+      "integrity": "sha512-pfBmT/8OYbhrb37ECk+fC1EstLBFxMTioF4uZrAEeOj3uCgjproj1qYmkpsQLJIoEOMPSIw1iSfBEMl10v1DDA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -9873,17 +9784,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -11958,9 +11858,9 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.25.2",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.25.2.tgz",
-      "integrity": "sha512-1Nj1fusFd+rIMKU/qC9yGKVG+3ofh11d3OdBQKL1iVvQfKvcB8vhvTGQf2TkfxW3bamxN+hCZIXmNuU0mRkyDg==",
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.26.2.tgz",
+      "integrity": "sha512-2XnWsZToKj76trGtEZzx5ELD/qOICFEprEeUntImmitQFVUkea27fiWdUSITArI356Y1qynpXZINW+Unbhky/A==",
       "license": "MIT",
       "dependencies": {
         "react-freeze": "^1.0.0",
@@ -11968,7 +11868,7 @@
       },
       "peerDependencies": {
         "react": "*",
-        "react-native": ">=0.82.0"
+        "react-native": "*"
       }
     },
     "node_modules/react-native-web": {
@@ -12662,15 +12562,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/split-on-first": {
       "version": "1.1.0",
@@ -16441,87 +16332,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="
     },
-    "@vue/compiler-core": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
-      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.45",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "@vue/compiler-dom": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
-      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@vue/compiler-core": "3.2.45",
-        "@vue/shared": "3.2.45"
-      }
-    },
-    "@vue/compiler-sfc": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
-      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.45",
-        "@vue/compiler-dom": "3.2.45",
-        "@vue/compiler-ssr": "3.2.45",
-        "@vue/reactivity-transform": "3.2.45",
-        "@vue/shared": "3.2.45",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7",
-        "postcss": "^8.1.10",
-        "source-map": "^0.6.1"
-      }
-    },
-    "@vue/compiler-ssr": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
-      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@vue/compiler-dom": "3.2.45",
-        "@vue/shared": "3.2.45"
-      }
-    },
-    "@vue/reactivity-transform": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
-      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.45",
-        "@vue/shared": "3.2.45",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7"
-      }
-    },
-    "@vue/shared": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
-      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -18065,14 +17875,6 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
-    "estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -18360,9 +18162,9 @@
       }
     },
     "expo-audio": {
-      "version": "56.0.12",
-      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-56.0.12.tgz",
-      "integrity": "sha512-ne2UIO/HsQoBL9e+tGs5N9Sf3NyW5sJMm4sDkexbSJRc2IchLDG+9Msu/+l5N4RlZ8SiF42wRyWsh/Usg+SwOw==",
+      "version": "56.0.13",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-56.0.13.tgz",
+      "integrity": "sha512-pfBmT/8OYbhrb37ECk+fC1EstLBFxMTioF4uZrAEeOj3uCgjproj1qYmkpsQLJIoEOMPSIw1iSfBEMl10v1DDA==",
       "requires": {}
     },
     "expo-build-properties": {
@@ -20558,17 +20360,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
     "make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -21939,9 +21730,9 @@
       "requires": {}
     },
     "react-native-screens": {
-      "version": "4.25.2",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.25.2.tgz",
-      "integrity": "sha512-1Nj1fusFd+rIMKU/qC9yGKVG+3ofh11d3OdBQKL1iVvQfKvcB8vhvTGQf2TkfxW3bamxN+hCZIXmNuU0mRkyDg==",
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.26.2.tgz",
+      "integrity": "sha512-2XnWsZToKj76trGtEZzx5ELD/qOICFEprEeUntImmitQFVUkea27fiWdUSITArI356Y1qynpXZINW+Unbhky/A==",
       "requires": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -22409,14 +22200,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "split-on-first": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "color": "^4.2.3",
     "expo": "~56.0.15",
     "expo-asset": "~56.0.19",
-    "expo-audio": "~56.0.12",
+    "expo-audio": "~56.0.13",
     "expo-build-properties": "~56.0.22",
     "expo-dev-client": "~56.0.22",
     "expo-font": "~56.0.7",
@@ -67,7 +67,7 @@
     "react-dom": "19.2.3",
     "react-native": "0.85.3",
     "react-native-safe-area-context": "~5.7.0",
-    "react-native-screens": "4.25.2",
+    "react-native-screens": "~4.26.0",
     "react-native-web": "^0.21.2",
     "zustand": "^5.0.14"
   },

--- a/src/screens/home-screen/home-screen.tsx
+++ b/src/screens/home-screen/home-screen.tsx
@@ -83,25 +83,41 @@ export const HomeScreen: FC<NativeStackScreenProps<RootStackParamList, "Home">> 
         </Animated.Text>
       </View>
       <Pressable
-        className="w-72 max-w-xs items-center rounded-lg px-8 py-2 text-center"
+        className="w-72 max-w-xs items-center rounded-lg px-4 py-2"
         style={{ backgroundColor: colors.pastel["orange-light"] }}
         onPress={handleStartButtonPress}
         testID="home.start-session"
         accessibilityRole="button"
       >
-        <Text className="py-1 text-lg text-slate-800">Start a new session</Text>
+        <Text
+          adjustsFontSizeToFit
+          className="w-full py-1 text-center font-breathly-regular text-lg text-slate-800"
+          maxFontSizeMultiplier={1.2}
+          minimumFontScale={0.85}
+          numberOfLines={1}
+        >
+          Start a new session
+        </Text>
       </Pressable>
       <Animated.Text className="bg-red my-2 text-center font-breathly-regular text-lg font-light text-slate-500">
         or
       </Animated.Text>
       <Pressable
-        className="mb-20 w-72 max-w-xs items-center rounded-lg px-8 py-2 text-center"
+        className="mb-20 w-72 max-w-xs items-center rounded-lg px-4 py-2"
         style={{ backgroundColor: colors.pastel["gray-light"] }}
         onPress={handleCustomizeButtonPress}
         testID="home.customize"
         accessibilityRole="button"
       >
-        <Text className="py-1 text-lg text-slate-800">Customize the experience</Text>
+        <Text
+          adjustsFontSizeToFit
+          className="w-full py-1 text-center font-breathly-regular text-lg text-slate-800"
+          maxFontSizeMultiplier={1.2}
+          minimumFontScale={0.85}
+          numberOfLines={1}
+        >
+          Customize the experience
+        </Text>
       </Pressable>
     </Animated.View>
   );

--- a/src/services/__tests__/audio.test.ts
+++ b/src/services/__tests__/audio.test.ts
@@ -1,0 +1,118 @@
+jest.mock("expo-audio", () => ({
+  createAudioPlayer: jest.fn(),
+  setAudioModeAsync: jest.fn(),
+}));
+
+jest.mock("expo-asset", () => ({
+  Asset: {
+    fromModule: jest.fn(),
+  },
+}));
+
+jest.mock("@breathly/assets/sounds", () => ({
+  sounds: {
+    endingBell: 1,
+    lauraBreatheIn: 2,
+    lauraBreatheOut: 3,
+    lauraHold: 4,
+    paulBreatheIn: 5,
+    paulBreatheOut: 6,
+    paulHold: 7,
+    cueBell1: 8,
+    cueBell2: 9,
+  },
+}));
+
+import { createAudioPlayer, setAudioModeAsync } from "expo-audio";
+import { Asset } from "expo-asset";
+import { Platform } from "react-native";
+import {
+  playGuidedBreathingSound,
+  releaseGuidedBreathingAudio,
+  setupGuidedBreathingAudio,
+} from "../audio";
+
+const mockCreateAudioPlayer = createAudioPlayer as jest.Mock;
+const mockSetAudioModeAsync = setAudioModeAsync as jest.Mock;
+const mockAssetFromModule = Asset.fromModule as jest.Mock;
+const mockPlayers: Array<{
+  source: unknown;
+  pause: jest.Mock;
+  play: jest.Mock;
+  remove: jest.Mock;
+  seekTo: jest.Mock;
+}> = [];
+const originalPlatform = Platform.OS;
+
+beforeAll(() => {
+  Object.defineProperty(Platform, "OS", { configurable: true, value: "android" });
+});
+
+beforeEach(() => {
+  mockSetAudioModeAsync.mockResolvedValue(undefined);
+  mockCreateAudioPlayer.mockImplementation((source: unknown) => {
+    const player = {
+      source,
+      pause: jest.fn(),
+      play: jest.fn(),
+      remove: jest.fn(),
+      seekTo: jest.fn().mockResolvedValue(undefined),
+    };
+    mockPlayers.push(player);
+    return player;
+  });
+  mockAssetFromModule.mockImplementation((assetId: number) => {
+    const asset: {
+      uri: string;
+      localUri: string | null;
+      downloadAsync: jest.Mock;
+    } = {
+      uri: `asset://${assetId}`,
+      localUri: null,
+      downloadAsync: jest.fn(),
+    };
+    asset.downloadAsync.mockImplementation(async () => {
+      asset.localUri = `file:///audio/${assetId}.mp3`;
+      return asset;
+    });
+    return asset;
+  });
+});
+
+afterEach(async () => {
+  await releaseGuidedBreathingAudio();
+  mockPlayers.length = 0;
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  Object.defineProperty(Platform, "OS", { configurable: true, value: originalPlatform });
+});
+
+describe("guided breathing audio", () => {
+  it("configures audio and materializes every bundled sound before creating players", async () => {
+    await setupGuidedBreathingAudio("laura");
+
+    expect(mockSetAudioModeAsync).toHaveBeenCalledWith({
+      playsInSilentMode: true,
+      shouldPlayInBackground: false,
+      interruptionMode: "duckOthers",
+    });
+    expect(mockAssetFromModule).toHaveBeenCalledTimes(4);
+    expect(mockCreateAudioPlayer.mock.calls.map(([source]) => source)).toEqual([
+      { assetId: 1, uri: "file:///audio/1.mp3" },
+      { assetId: 2, uri: "file:///audio/2.mp3" },
+      { assetId: 3, uri: "file:///audio/3.mp3" },
+      { assetId: 4, uri: "file:///audio/4.mp3" },
+    ]);
+  });
+
+  it("rewinds a prepared cue before playing it", async () => {
+    await setupGuidedBreathingAudio("bell");
+
+    await playGuidedBreathingSound("breatheIn");
+
+    expect(mockPlayers[1].seekTo).toHaveBeenCalledWith(0);
+    expect(mockPlayers[1].play).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -1,20 +1,21 @@
 import {
-  clearPreloadedSource,
   createAudioPlayer,
-  preload,
   setAudioModeAsync,
   type AudioPlayer,
   type AudioSource,
 } from "expo-audio";
+import { Asset } from "expo-asset";
+import { Platform } from "react-native";
 import { sounds } from "@breathly/assets/sounds";
 import { GuidedBreathingMode } from "@breathly/types/guided-breathing-mode";
 import { GuidedBreathingStep } from "@breathly/types/guided-breathing-step";
 
-void setAudioModeAsync({
-  playsInSilentMode: true,
-  shouldPlayInBackground: false,
-  interruptionMode: "mixWithOthers",
-}).catch(() => undefined);
+const configureAudioMode = () =>
+  setAudioModeAsync({
+    playsInSilentMode: true,
+    shouldPlayInBackground: false,
+    interruptionMode: Platform.OS === "android" ? "duckOthers" : "mixWithOthers",
+  });
 
 type GuidedBreathingAudioSounds = {
   [key in GuidedBreathingMode]: {
@@ -51,7 +52,6 @@ type CurrentGuidedBreathingSounds = {
 
 let currentGuidedBreathingSounds: CurrentGuidedBreathingSounds | undefined;
 let endingBellSound: AudioPlayer | undefined;
-let currentPreloadedAudioSources: AudioSource[] = [];
 let audioOperation = Promise.resolve();
 let requestedAudioGeneration = 0;
 
@@ -64,17 +64,28 @@ const enqueueAudioOperation = (operation: () => Promise<void>) => {
 const disposeCurrentAudio = async () => {
   const guidedBreathingSounds = currentGuidedBreathingSounds;
   const bellSound = endingBellSound;
-  const preloadedAudioSources = currentPreloadedAudioSources;
 
   currentGuidedBreathingSounds = undefined;
   endingBellSound = undefined;
-  currentPreloadedAudioSources = [];
 
   bellSound?.remove();
   guidedBreathingSounds?.breatheIn.remove();
   guidedBreathingSounds?.breatheOut.remove();
   guidedBreathingSounds?.hold.remove();
-  await Promise.all(preloadedAudioSources.map((source) => clearPreloadedSource(source)));
+};
+
+const prepareAudioSource = async (source: AudioSource): Promise<AudioSource> => {
+  if (typeof source !== "number") return source;
+
+  // Materialize bundled audio before creating the native player. This gives setup
+  // an awaitable readiness boundary and avoids Android resource-URI loading races.
+  const asset = Asset.fromModule(source);
+  await asset.downloadAsync();
+
+  return {
+    assetId: source,
+    uri: asset.localUri ?? asset.uri,
+  };
 };
 
 export function setupGuidedBreathingAudio(guidedBreathingMode: GuidedBreathingMode) {
@@ -90,19 +101,16 @@ export function setupGuidedBreathingAudio(guidedBreathingMode: GuidedBreathingMo
     await disposeCurrentAudio();
     if (audioGeneration !== requestedAudioGeneration) return;
 
-    await Promise.all(audioSources.map((source) => preload(source)));
-    if (audioGeneration !== requestedAudioGeneration) {
-      await Promise.all(audioSources.map((source) => clearPreloadedSource(source)));
-      return;
-    }
+    await configureAudioMode();
+    const preparedAudioSources = await Promise.all(audioSources.map(prepareAudioSource));
+    if (audioGeneration !== requestedAudioGeneration) return;
 
-    endingBellSound = createAudioPlayer(audioSources[0]);
+    endingBellSound = createAudioPlayer(preparedAudioSources[0]);
     currentGuidedBreathingSounds = {
-      breatheIn: createAudioPlayer(audioSources[1]),
-      breatheOut: createAudioPlayer(audioSources[2]),
-      hold: createAudioPlayer(audioSources[3]),
+      breatheIn: createAudioPlayer(preparedAudioSources[1]),
+      breatheOut: createAudioPlayer(preparedAudioSources[2]),
+      hold: createAudioPlayer(preparedAudioSources[3]),
     };
-    currentPreloadedAudioSources = audioSources;
   });
 }
 


### PR DESCRIPTION
## Summary

- Materialize bundled audio assets before creating Expo audio players and use Android-appropriate audio interruption behavior.
- Remove the tiny Android 12+ system-splash text flash while preserving Breathly's full-screen splash artwork.
- Keep the home action labels centered and readable on narrow devices and at large system font scales.
- Advance the Android version code to `3145750` for the corrected internal release.

## Root cause

Recent Android versions could race while opening bundled resource URIs through the Expo audio preload path, leaving guided breathing cues silent on affected devices. Android 12+ also treated the existing full-screen splash artwork as a masked app icon, briefly shrinking its text into the center of the screen. Finally, the action labels depended on implicit text alignment and unrestricted font scaling, which caused wrapping and left alignment on some devices.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test -- --no-watchman` — 6 suites, 27 tests passed
- Expo Doctor — 21/21 checks passed
- Android production bundle export verified all bell and voice assets
- Android API 37 emulator: cold-launch splash sequence and 2.0× font-scale stress test
- Physical Android device: audio, splash, and home layout verified
- Signed EAS production AAB built and accepted on Google Play's internal testing track
- Adversarial release-diff and secret-leak review completed with no release blocker

This clean PR branch is based on the current `master`; its resulting source tree is identical to the internally tested release commit.
