### PR TITLE
fix: three silent failure paths at startup and at the end of a session

### DIFF
--- a/src/core/entry-point.tsx
+++ b/src/core/entry-point.tsx
@@ -33,7 +33,7 @@ export const EntryPoint: FC = () => {
 // Initializes the app state and, once done, hides the splash screen and shows
 // the AppRouter
 const Main: FC = () => {
-  const [areFontsLoaded] = Font.useFonts(fontAssets);
+  const [areFontsLoaded, fontLoadError] = Font.useFonts(fontAssets);
   const theme = useSettingsStore((state) => state.theme);
   const shouldFollowSystemDarkMode = useSettingsStore((state) => state.shouldFollowSystemDarkMode);
   const hydrated = useHydration();
@@ -49,7 +49,10 @@ const Main: FC = () => {
     }
   }, [hydrated, shouldFollowSystemDarkMode, theme]);
 
-  if (!hydrated || !areFontsLoaded) {
+  // `useFonts` keeps `loaded` false for ever once a load fails, so waiting on it alone would
+  // hold the app on an empty view with no way out. A missing typeface only costs the custom
+  // face; carry on with the system one.
+  if (!hydrated || (!areFontsLoaded && !fontLoadError)) {
     return <View />;
   }
 

--- a/src/screens/exercise-screen/use-exercise-audio.tsx
+++ b/src/screens/exercise-screen/use-exercise-audio.tsx
@@ -10,15 +10,14 @@ import { GuidedBreathingMode } from "@breathly/types/guided-breathing-mode";
 import { StepMetadata } from "@breathly/types/step-metadata";
 
 export const useExerciseAudio = (guidedBreathingVoice: GuidedBreathingMode) => {
-  const [audioReady, setAudioReady] = useState(guidedBreathingVoice === "disabled");
+  const [audioReady, setAudioReady] = useState(false);
 
   useEffect(() => {
     let active = true;
-    if (guidedBreathingVoice === "disabled") {
-      setAudioReady(true);
-      return;
-    }
 
+    // Every mode needs setup, including "disabled": the ending bell is not guidance, and the
+    // service builds it on its own for the modes that have no step cues. Skipping setup here
+    // left the bell player undefined, so a session with the voice off ended in silence.
     setAudioReady(false);
     setupGuidedBreathingAudio(guidedBreathingVoice)
       .then(() => {

--- a/src/stores/__tests__/settings.test.ts
+++ b/src/stores/__tests__/settings.test.ts
@@ -1,0 +1,76 @@
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+const mockRemoveItem = jest.fn();
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: (name: string) => mockGetItem(name),
+    setItem: (name: string, value: string) => mockSetItem(name, value),
+    removeItem: (name: string) => mockRemoveItem(name),
+  },
+}));
+
+import { defaultSettingsState } from "../settings-state";
+
+// The store starts hydrating the moment the module loads, so each case configures the
+// storage first and then loads a fresh copy of the store.
+const loadSettingsStore = async () => {
+  jest.resetModules();
+  const { useSettingsStore } = require("../settings") as typeof import("../settings");
+  await useSettingsStore.persist.rehydrate();
+  return useSettingsStore;
+};
+
+const storedSettings = (overrides: Record<string, unknown>) =>
+  JSON.stringify({ state: { ...defaultSettingsState, ...overrides }, version: 0 });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSetItem.mockResolvedValue(undefined);
+  mockRemoveItem.mockResolvedValue(undefined);
+});
+
+describe("settings persistence", () => {
+  it("finishes hydration on the defaults when the stored payload cannot be read", async () => {
+    mockGetItem.mockRejectedValue(new Error("storage unavailable"));
+
+    const useSettingsStore = await loadSettingsStore();
+
+    // Hydration must complete. If it does not, `useHydration` never turns true and the app
+    // shows an empty view on every launch.
+    expect(useSettingsStore.persist.hasHydrated()).toBe(true);
+    expect(useSettingsStore.getState().theme).toBe(defaultSettingsState.theme);
+  });
+
+  it("finishes hydration on the defaults when the stored payload is damaged", async () => {
+    // A write cut short by a process kill leaves incomplete JSON behind.
+    mockGetItem.mockResolvedValue('{"state":{"theme":"dar');
+
+    const useSettingsStore = await loadSettingsStore();
+
+    expect(useSettingsStore.persist.hasHydrated()).toBe(true);
+    expect(useSettingsStore.getState().theme).toBe(defaultSettingsState.theme);
+  });
+
+  it("restores stored settings and keeps the store actions", async () => {
+    mockGetItem.mockResolvedValue(storedSettings({ theme: "dark", vibrationEnabled: false }));
+
+    const useSettingsStore = await loadSettingsStore();
+
+    expect(useSettingsStore.persist.hasHydrated()).toBe(true);
+    expect(useSettingsStore.getState().theme).toBe("dark");
+    expect(useSettingsStore.getState().vibrationEnabled).toBe(false);
+    expect(typeof useSettingsStore.getState().setTheme).toBe("function");
+  });
+
+  it("repairs an out-of-range stored value instead of failing", async () => {
+    mockGetItem.mockResolvedValue(storedSettings({ theme: "sepia", timeLimit: -1 }));
+
+    const useSettingsStore = await loadSettingsStore();
+
+    expect(useSettingsStore.persist.hasHydrated()).toBe(true);
+    expect(useSettingsStore.getState().theme).toBe("light");
+    expect(useSettingsStore.getState().timeLimit).toBe(0);
+  });
+});

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,7 +1,12 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useEffect, useState } from "react";
 import { create } from "zustand";
-import { createJSONStorage, persist, subscribeWithSelector } from "zustand/middleware";
+import {
+  persist,
+  subscribeWithSelector,
+  type PersistStorage,
+  type StorageValue,
+} from "zustand/middleware";
 import { patternPresets } from "@breathly/assets/pattern-presets";
 import {
   adjustTimeLimit,
@@ -25,6 +30,38 @@ interface SettingsStore extends PersistedSettingsState {
   setTheme: (theme: Theme) => unknown;
   setVibrationEnabled: (vibrationEnabled: boolean) => unknown;
 }
+
+// An unreadable or damaged payload must never stop hydration. Zustand leaves `hasHydrated`
+// false when the read rejects, `useHydration` then never turns true, and the app renders an
+// empty view on every launch — with no way back, because the app has no network. Both
+// failures mean the same thing here: there are no usable stored settings. Report that, and
+// let the store start from its defaults.
+const settingsStorage: PersistStorage<SettingsStore> = {
+  getItem: async (name) => {
+    try {
+      const storedValue = await AsyncStorage.getItem(name);
+      if (storedValue == null) return null;
+      return JSON.parse(storedValue) as StorageValue<SettingsStore>;
+    } catch {
+      return null;
+    }
+  },
+  setItem: async (name, value) => {
+    try {
+      await AsyncStorage.setItem(name, JSON.stringify(value));
+    } catch {
+      // A failed write costs the user one setting. Rejecting would only add an unhandled
+      // rejection on top, and would not bring the value back.
+    }
+  },
+  removeItem: async (name) => {
+    try {
+      await AsyncStorage.removeItem(name);
+    } catch {
+      // Same reasoning as `setItem`.
+    }
+  },
+};
 
 export const useSettingsStore = create<SettingsStore>()(
   subscribeWithSelector(
@@ -54,7 +91,7 @@ export const useSettingsStore = create<SettingsStore>()(
       }),
       {
         name: "settings-storage",
-        storage: createJSONStorage(() => AsyncStorage),
+        storage: settingsStorage,
         merge: mergePersistedSettingsState,
       },
     ),


### PR DESCRIPTION
Three unrelated bugs that all end in the app giving the user nothing.

### The app can be bricked permanently by a damaged settings payload

Zustand's persist middleware leaves `hasHydrated` false and never fires its finish-hydration listeners when the storage read rejects or the stored text is not valid JSON. `useHydration` never turns true, so `Main` returns a bare `<View />` — with no timeout and no error branch — on every launch, for ever.

The store is written on every settings change, so a process kill or power loss mid-write leaves a truncated payload behind. An AsyncStorage read can also fail on its own. The splash watchdog then hides the splash after 8 seconds and reveals a blank screen. There is no in-app recovery and the app has no network, so the only way out is clearing app data or reinstalling.

`createJSONStorage` is replaced with a storage adapter that reports an unreadable or damaged payload as "nothing stored". Hydration completes and the store starts from its defaults.

### A font that fails to load produces the identical dead screen

`Font.useFonts` keeps `loaded` false and sets its error entry when a load fails, and the error entry was being discarded. Same empty view, same lack of recovery, different cause. The error is now read and treated as a reason to continue: a typeface that cannot load costs the custom face, not the whole app.

### The ending bell never plays when the guided voice is off

`useExerciseAudio` returned before calling `setupGuidedBreathingAudio` whenever the voice was `disabled`, so the bell player was never created and `playEndingBellSound` did nothing. Since the completion haptic is suppressed as well, the session ended with no signal at all — which matters most for exactly the people who turn the voice off and close their eyes.

The audio service already supports this mode deliberately: it builds the ending bell and skips only the step cues, and `audio.test.ts` covers that. The caller was preventing the behaviour the service provides. Setup now always runs and the service decides which players to build.

## Tests

New `src/stores/__tests__/settings.test.ts` covers hydration when the read rejects, when the stored JSON is truncated, when values are out of range, and the normal restore path. The two failure cases fail against the previous code and pass against this branch.

The font and audio fixes are not covered — a hook-level test needs `@testing-library/react-native`, which is not currently a dependency.

`typecheck`, `lint`, `format:check` and `test` all pass (42 tests).