### PR TITLE
fix: finish sessions after breathing cycle

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -41,8 +41,8 @@ maestro test .maestro/flows/settings-persistence.yaml
 Each top-level flow resets application data so it can run independently. The settings flow also
 kills and relaunches the app without clearing data to verify AsyncStorage persistence.
 
-The completion flow sets the shortest time limit and then waits for the exercise to end by itself.
-It runs for approximately 90 seconds, thus it is much slower than the other flows.
+The completion flow sets the shortest time limit and then waits for the current breathing cycle to
+end. It runs for approximately 90 seconds, thus it is much slower than the other flows.
 
 ## Cross-version visual comparison
 

--- a/.maestro/flows/exercise-completion.yaml
+++ b/.maestro/flows/exercise-completion.yaml
@@ -1,5 +1,5 @@
 appId: com.mmazzarolo.breathly
-name: Exercise completes after the last exhale
+name: Exercise completes after the current breathing cycle
 ---
 - clearState
 - launchApp
@@ -31,9 +31,9 @@ name: Exercise completes after the last exhale
     visible:
       id: "exercise.running"
     timeout: 8000
-# The time limit does not stop the exercise immediately: the exercise continues
-# to the end of the current exhale. With the default pattern this adds a maximum
-# of twelve seconds to the minute of the time limit. The timeout is much longer,
+# The time limit does not stop the exercise immediately: the exercise completes
+# the current breathing cycle. With the default pattern this can add up to
+# seventeen seconds to the minute of the time limit. The timeout is much longer,
 # because a slow emulator makes the exercise clock run behind the real time.
 - extendedWaitUntil:
     visible:

--- a/src/screens/exercise-screen/__tests__/exercise-session.test.ts
+++ b/src/screens/exercise-screen/__tests__/exercise-session.test.ts
@@ -123,18 +123,19 @@ describe("exercise step transitions", () => {
     expect(getExerciseStepTransition("afterExhale", "inhale", false)).toBe("startStep");
   });
 
-  it("stops the exercise at the end of the exhale after the time limit", () => {
-    expect(getExerciseStepTransition("exhale", "afterExhale", true)).toBe("complete");
+  it("stops the exercise when the current cycle returns to the inhale", () => {
     expect(getExerciseStepTransition("exhale", "inhale", true)).toBe("complete");
-  });
-
-  it("stops the exercise at the end of the hold that follows the exhale", () => {
     expect(getExerciseStepTransition("afterExhale", "inhale", true)).toBe("complete");
   });
 
-  it("keeps breathing after the time limit until the lungs are empty", () => {
+  it("does not complete before every active step of the current cycle", () => {
     expect(getExerciseStepTransition("inhale", "afterInhale", true)).toBe("startStep");
     expect(getExerciseStepTransition("inhale", "exhale", true)).toBe("startStep");
     expect(getExerciseStepTransition("afterInhale", "exhale", true)).toBe("startStep");
+    expect(getExerciseStepTransition("exhale", "afterExhale", true)).toBe("startStep");
+  });
+
+  it("does not complete on the first inhale", () => {
+    expect(getExerciseStepTransition(undefined, "inhale", true)).toBe("startStep");
   });
 });

--- a/src/screens/exercise-screen/__tests__/exercise-session.test.ts
+++ b/src/screens/exercise-screen/__tests__/exercise-session.test.ts
@@ -128,6 +128,12 @@ describe("exercise step transitions", () => {
     expect(getExerciseStepTransition("afterExhale", "inhale", true)).toBe("complete");
   });
 
+  it("finishes a custom inhale-exhale pattern after its exhale", () => {
+    // A custom 12-0-12-0 pattern skips both holds, leaving inhale and exhale.
+    expect(getExerciseStepTransition("inhale", "exhale", true)).toBe("startStep");
+    expect(getExerciseStepTransition("exhale", "inhale", true)).toBe("complete");
+  });
+
   it("does not complete before every active step of the current cycle", () => {
     expect(getExerciseStepTransition("inhale", "afterInhale", true)).toBe("startStep");
     expect(getExerciseStepTransition("inhale", "exhale", true)).toBe("startStep");

--- a/src/screens/exercise-screen/__tests__/timer.test.tsx
+++ b/src/screens/exercise-screen/__tests__/timer.test.tsx
@@ -1,8 +1,8 @@
-import { act, render } from '@testing-library/react-native';
-import React from 'react';
-import { Timer } from '../timer';
+import { act, render } from "@testing-library/react-native";
+import React from "react";
+import { Timer } from "../timer";
 
-describe('Timer', () => {
+describe("Timer", () => {
   beforeEach(() => {
     jest.useFakeTimers();
   });
@@ -11,7 +11,7 @@ describe('Timer', () => {
     jest.useRealTimers();
   });
 
-  it('arms exercise completion in the tick that reaches the limit', async () => {
+  it("arms exercise completion in the tick that reaches the limit", async () => {
     const onLimitReached = jest.fn();
     const onActiveElapsedChange = jest.fn(() => {
       expect(onLimitReached).toHaveBeenCalledTimes(1);
@@ -34,7 +34,7 @@ describe('Timer', () => {
     expect(onActiveElapsedChange).toHaveBeenLastCalledWith(250);
   });
 
-  it('arms completion when it mounts after the limit', async () => {
+  it("arms completion when it mounts after the limit", async () => {
     const onLimitReached = jest.fn();
 
     await render(
@@ -53,7 +53,7 @@ describe('Timer', () => {
     expect(onLimitReached).toHaveBeenCalledTimes(1);
   });
 
-  it('does not arm completion when the timer is unlimited', async () => {
+  it("does not arm completion when the timer is unlimited", async () => {
     const onLimitReached = jest.fn();
 
     await render(

--- a/src/screens/exercise-screen/__tests__/timer.test.tsx
+++ b/src/screens/exercise-screen/__tests__/timer.test.tsx
@@ -1,0 +1,74 @@
+import { act, render } from '@testing-library/react-native';
+import React from 'react';
+import { Timer } from '../timer';
+
+describe('Timer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('arms exercise completion in the tick that reaches the limit', async () => {
+    const onLimitReached = jest.fn();
+    const onActiveElapsedChange = jest.fn(() => {
+      expect(onLimitReached).toHaveBeenCalledTimes(1);
+    });
+
+    await render(
+      <Timer
+        limit={250}
+        initialActiveElapsedMs={0}
+        onActiveElapsedChange={onActiveElapsedChange}
+        onLimitReached={onLimitReached}
+      />,
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(750);
+    });
+
+    expect(onLimitReached).toHaveBeenCalledTimes(1);
+    expect(onActiveElapsedChange).toHaveBeenLastCalledWith(250);
+  });
+
+  it('arms completion when it mounts after the limit', async () => {
+    const onLimitReached = jest.fn();
+
+    await render(
+      <Timer
+        limit={250}
+        initialActiveElapsedMs={250}
+        onActiveElapsedChange={() => undefined}
+        onLimitReached={onLimitReached}
+      />,
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(750);
+    });
+
+    expect(onLimitReached).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not arm completion when the timer is unlimited', async () => {
+    const onLimitReached = jest.fn();
+
+    await render(
+      <Timer
+        limit={0}
+        initialActiveElapsedMs={0}
+        onActiveElapsedChange={() => undefined}
+        onLimitReached={onLimitReached}
+      />,
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(750);
+    });
+
+    expect(onLimitReached).not.toHaveBeenCalled();
+  });
+});

--- a/src/screens/exercise-screen/exercise-screen.tsx
+++ b/src/screens/exercise-screen/exercise-screen.tsx
@@ -218,8 +218,8 @@ const ExerciseRunningFragment: FC<ExerciseRunningFragmentProps> = ({
 
   // The time limit does not stop the exercise on its own: it only arms the
   // completion. The step transition below then stops the exercise at the end of
-  // the first step that leaves the lungs empty.
-  const timeLimitReachedRef = useRef(false);
+  // the current breathing-cycle iteration.
+  const timeLimitReachedRef = useRef(timeLimit > 0 && initialActiveElapsedMs >= timeLimit);
   const completionStartedRef = useRef(false);
 
   const startCompletion = () => {

--- a/src/screens/exercise-screen/exercise-session.ts
+++ b/src/screens/exercise-screen/exercise-session.ts
@@ -47,22 +47,19 @@ export const getActiveTickDeltaMs = (
 
 export type ExerciseStepTransition = "none" | "startStep" | "complete";
 
-// The exercise must not stop while the lungs are full: the user would then hold
-// the breath while the completion screen appears. These two steps end with empty
-// lungs, thus they are the only safe points at which the exercise can stop.
-const endsWithEmptyLungs = (stepId: StepId | undefined) =>
-  stepId === "exhale" || stepId === "afterExhale";
-
 // The time limit usually occurs in the middle of a step. The exercise then
-// continues to the first step boundary that leaves the lungs empty, and it stops
-// there. This adds at most one inhale, one hold and one exhale to the session.
+// completes the current iteration before it stops. Every pattern starts with an
+// inhale, and an inhale cannot be skipped, so returning to it marks the end of
+// every possible cycle, including patterns that skip one or both holds.
 export const getExerciseStepTransition = (
   previousStepId: StepId | undefined,
   currentStepId: StepId,
   timeLimitReached: boolean,
 ): ExerciseStepTransition => {
   if (previousStepId === currentStepId) return "none";
-  if (timeLimitReached && endsWithEmptyLungs(previousStepId)) return "complete";
+  if (timeLimitReached && previousStepId != null && currentStepId === "inhale") {
+    return "complete";
+  }
   return "startStep";
 };
 

--- a/src/screens/exercise-screen/timer.tsx
+++ b/src/screens/exercise-screen/timer.tsx
@@ -50,10 +50,15 @@ export const Timer: FC<Props> = ({
     previousTickAtMs.current = currentTickAtMs;
     if (activeTickDeltaMs === 0) return;
 
+    const elapsedWasBeforeLimit = limit > 0 && elapsedTimeRef.current < limit;
     const nextElapsedTimeMs = limit
       ? Math.min(elapsedTimeRef.current + activeTickDeltaMs, limit)
       : elapsedTimeRef.current + activeTickDeltaMs;
     elapsedTimeRef.current = nextElapsedTimeMs;
+    if (elapsedWasBeforeLimit && nextElapsedTimeMs === limit && !limitReachedRef.current) {
+      limitReachedRef.current = true;
+      onLimitReached();
+    }
     setElapsedTimeMs(nextElapsedTimeMs);
     onActiveElapsedChange(nextElapsedTimeMs);
   }, timerRefreshIntervalMs);
@@ -61,11 +66,11 @@ export const Timer: FC<Props> = ({
   const remainingTimeMs = limit ? Math.max(0, limit - elapsedTimeMs) : undefined;
   const limitReached = remainingTimeMs === 0;
 
-  // The exercise continues until the end of the current exhale, thus the clock
+  // The exercise completes its current breathing-cycle iteration, thus the clock
   // stays at 00:00 for some seconds. The clock is complete and only the last
-  // breath remains: the timer crossfades to that message. It must not fade
-  // away, because a blank screen tells the user nothing about the time that the
-  // exercise still needs.
+  // breath remains: the timer crossfades to that message. It must not fade away,
+  // because a blank screen tells the user nothing about the time that the exercise
+  // still needs.
   useEffect(() => {
     if (!limitReached) {
       const showAnimation = animate(opacityAnimVal, {
@@ -99,6 +104,9 @@ export const Timer: FC<Props> = ({
     };
   }, [limitReached, opacityAnimVal]);
 
+  // A resumed session may already be at the limit when this timer mounts. The
+  // exercise screen arms completion before mounting the loop; this effect keeps
+  // the Timer callback contract intact for any other caller.
   useEffect(() => {
     if (limitReached && !limitReachedRef.current) {
       limitReachedRef.current = true;


### PR DESCRIPTION
Timer expiry now arms completion synchronously, then the session completes only after the active breathing cycle returns to its next inhale. This preserves skipped-hold patterns, handles resume after expiry, and prevents duplicate completion callbacks. Added timer coverage for expiry, resume, and unlimited sessions.

Closes #55
Closes #115