### PR TITLE
feat: add configurable start delay

### DIFF
--- a/src/screens/exercise-screen/__tests__/accessibility-announcements.test.ts
+++ b/src/screens/exercise-screen/__tests__/accessibility-announcements.test.ts
@@ -21,6 +21,7 @@ describe("exercise accessibility labels", () => {
   });
 
   it("reads the countdown of the interlude", () => {
-    expect(getInterludeAccessibilityLabel(3)).toBe("Starting session in 3");
+    expect(getInterludeAccessibilityLabel(3)).toBe("Starting session in 3 seconds");
+    expect(getInterludeAccessibilityLabel(1)).toBe("Starting session in 1 second");
   });
 });

--- a/src/screens/exercise-screen/__tests__/interlude.test.ts
+++ b/src/screens/exercise-screen/__tests__/interlude.test.ts
@@ -1,0 +1,86 @@
+import { act, render, screen } from "@testing-library/react-native";
+import React from "react";
+import { ExerciseInterlude, getInterludeInitialStep } from "../interlude";
+
+jest.mock("@breathly/utils/animate", () => ({
+  animate: (_value: unknown, { duration = 0 }: { duration?: number }) => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    return {
+      start: (callback?: (result: { finished: boolean }) => void) => {
+        timeout = setTimeout(() => callback?.({ finished: true }), duration);
+      },
+      stop: () => {
+        if (timeout != null) clearTimeout(timeout);
+      },
+    };
+  },
+}));
+
+describe("exercise interlude", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("uses the selected preparation time as the initial countdown step", () => {
+    expect(getInterludeInitialStep(3_000)).toBe(3);
+    expect(getInterludeInitialStep(30_000)).toBe(30);
+  });
+
+  it("waits for every selected second after the subtitle appears", async () => {
+    const onComplete = jest.fn();
+
+    await render(React.createElement(ExerciseInterlude, { preparationTime: 3_000, onComplete }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(600);
+    });
+    expect(onComplete).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(screen.getByText("Starting session in \n3")).not.toBeNull();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1_000);
+    });
+    expect(screen.getByText("Starting session in \n2")).not.toBeNull();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1_000);
+    });
+    expect(screen.getByText("Starting session in \n1")).not.toBeNull();
+    expect(onComplete).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1_000);
+    });
+    expect(onComplete).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start an exercise after the countdown unmounts", async () => {
+    const onComplete = jest.fn();
+    const { unmount } = await render(
+      React.createElement(ExerciseInterlude, { preparationTime: 3_000, onComplete }),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1_000);
+    });
+    await unmount();
+
+    await act(async () => {
+      jest.advanceTimersByTime(3_000);
+    });
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/src/screens/exercise-screen/accessibility-announcements.ts
+++ b/src/screens/exercise-screen/accessibility-announcements.ts
@@ -27,7 +27,7 @@ export const getStepAccessibilityLabel = (label: string, durationMs: number) =>
   `${label}, ${formatStepDuration(durationMs)}`;
 
 export const getInterludeAccessibilityLabel = (secondsLeft: number) =>
-  `Starting session in ${secondsLeft}`;
+  `Starting session in ${secondsLeft} ${secondsLeft === 1 ? "second" : "seconds"}`;
 
 export const sessionCompleteAnnouncement = "Session complete";
 

--- a/src/screens/exercise-screen/exercise-screen.tsx
+++ b/src/screens/exercise-screen/exercise-screen.tsx
@@ -47,7 +47,7 @@ const screenReaderFallbackVoice: GuidedBreathingMode = "paul";
 export const ExerciseScreen: FC<NativeStackScreenProps<RootStackParamList, "Exercise">> = ({
   navigation,
 }) => {
-  const { guidedBreathingVoice } = useSettingsStore();
+  const { guidedBreathingVoice, preparationTime } = useSettingsStore();
   const screenReaderEnabled = useScreenReaderEnabled();
   // A user of a screen reader who disabled the voice has no channel that works
   // without sight, because the visuals carry the whole exercise. The voice
@@ -135,7 +135,9 @@ export const ExerciseScreen: FC<NativeStackScreenProps<RootStackParamList, "Exer
         },
       ]}
     >
-      {session.status === "interlude" && <ExerciseInterlude onComplete={handleInterludeComplete} />}
+      {session.status === "interlude" && (
+        <ExerciseInterlude preparationTime={preparationTime} onComplete={handleInterludeComplete} />
+      )}
       {session.status === "running" && (
         <>
           {colorScheme === "dark" && (

--- a/src/screens/exercise-screen/interlude.tsx
+++ b/src/screens/exercise-screen/interlude.tsx
@@ -14,21 +14,26 @@ import { useReduceMotion } from "@breathly/utils/use-accessibility-preferences";
 import { useOnMount } from "@breathly/utils/use-on-mount";
 
 interface Props {
+  preparationTime: number;
   onComplete: () => void;
 }
 
 const interludeInitialDelay = 600;
 const interludeAnimDuration = 400;
-const interludeInitialStep = 3;
+const secondMs = 1_000;
 
-export const ExerciseInterlude: FC<Props> = ({ onComplete }) => {
+export const getInterludeInitialStep = (preparationTime: number) =>
+  Math.max(1, Math.round(preparationTime / secondMs));
+
+export const ExerciseInterlude: FC<Props> = ({ preparationTime, onComplete }) => {
   const isDarkMode = useColorScheme() === "dark";
   const theme = useThemeColors();
   const reduceMotionEnabled = useReduceMotion();
   const isMountedRef = useRef(true);
   const containerAnimVal = useRef(new Animated.Value(1)).current;
   const subtitleAnimVal = useRef(new Animated.Value(0)).current;
-  const [step, setStep] = useState(interludeInitialStep);
+  const initialStep = getInterludeInitialStep(preparationTime);
+  const [step, setStep] = useState(initialStep);
 
   const goToStep = (nextStep: number) => {
     setStep(nextStep);
@@ -46,13 +51,12 @@ export const ExerciseInterlude: FC<Props> = ({ onComplete }) => {
   });
 
   const countDownAndHide = async () => {
-    await delay(1000);
-    if (!isMountedRef.current) return;
-    goToStep(2);
-    await delay(1000);
-    if (!isMountedRef.current) return;
-    goToStep(1);
-    await delay(1000);
+    for (let nextStep = initialStep - 1; nextStep >= 1; nextStep--) {
+      await delay(secondMs);
+      if (!isMountedRef.current) return;
+      goToStep(nextStep);
+    }
+    await delay(secondMs);
     if (!isMountedRef.current) return;
     hideContainerAnimation.start((done) => done && onComplete());
   };
@@ -61,7 +65,7 @@ export const ExerciseInterlude: FC<Props> = ({ onComplete }) => {
     await delay(interludeInitialDelay);
     showSubtitleAnimation.start(({ finished }) => {
       if (!finished) return;
-      announceLiveRegionUpdate(getInterludeAccessibilityLabel(interludeInitialStep));
+      announceLiveRegionUpdate(getInterludeAccessibilityLabel(initialStep));
       void countDownAndHide();
     });
   };

--- a/src/screens/settings-screen/__tests__/settings-screen.test.tsx
+++ b/src/screens/settings-screen/__tests__/settings-screen.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+import { useSettingsStore } from "@breathly/stores/settings";
+import { defaultSettingsState } from "@breathly/stores/settings-state";
+import { SettingsRootScreen } from "../settings-screen";
+
+const navigation = {
+  goBack: jest.fn(),
+  navigate: jest.fn(),
+  setOptions: jest.fn(),
+};
+
+describe("settings screen", () => {
+  beforeEach(() => {
+    useSettingsStore.setState(defaultSettingsState);
+  });
+
+  it("updates the preparation time from its stepper", async () => {
+    await render(
+      <SettingsRootScreen
+        {...({ navigation, route: {} } as unknown as React.ComponentProps<
+          typeof SettingsRootScreen
+        >)}
+      />,
+    );
+
+    expect(screen.getByTestId("settings.preparation-time.value").props.children).toBe(3);
+
+    await fireEvent.press(screen.getByTestId("settings.preparation-time.increase"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("settings.preparation-time.value").props.children).toBe(4);
+      expect(useSettingsStore.getState().preparationTime).toBe(4_000);
+    });
+  });
+});

--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -14,7 +14,9 @@ import {
 import {
   customPatternDurationLimits,
   customPatternStepSizeMs,
+  maximumPreparationTimeMs,
   maximumTimeLimitMs,
+  minimumPreparationTimeMs,
   type Theme,
 } from "@breathly/stores/settings-state";
 import { GuidedBreathingMode } from "@breathly/types/guided-breathing-mode";
@@ -29,6 +31,9 @@ export const SettingsRootScreen: FC<
   const timeLimit = useSettingsStore((state) => state.timeLimit);
   const increaseTimeLimit = useSettingsStore((state) => state.increaseTimeLimit);
   const decreaseTimeLimit = useSettingsStore((state) => state.decreaseTimeLimit);
+  const preparationTime = useSettingsStore((state) => state.preparationTime);
+  const increasePreparationTime = useSettingsStore((state) => state.increasePreparationTime);
+  const decreasePreparationTime = useSettingsStore((state) => state.decreasePreparationTime);
   const shouldFollowSystemDarkMode = useSettingsStore((state) => state.shouldFollowSystemDarkMode);
   const setShouldFollowSystemDarkMode = useSettingsStore(
     (state) => state.setShouldFollowSystemDarkMode,
@@ -135,6 +140,18 @@ export const SettingsRootScreen: FC<
             />
           </SettingsUI.Section>
           <SettingsUI.Section label="Timer" hideBottomBorderWeb>
+            <SettingsUI.StepperItem
+              label="Preparation time"
+              secondaryLabel="Time before the exercise starts, in seconds"
+              value={preparationTime / ms("1 sec")}
+              iconName="hourglass"
+              iconBackgroundColor="#fdba74"
+              onIncrease={increasePreparationTime}
+              onDecrease={decreasePreparationTime}
+              decreaseDisabled={preparationTime <= minimumPreparationTimeMs}
+              increaseDisabled={preparationTime >= maximumPreparationTimeMs}
+              testID="settings.preparation-time"
+            />
             <SettingsUI.StepperItem
               label="Exercise timer"
               secondaryLabel="Time limit in minutes"

--- a/src/stores/__tests__/settings-state.test.ts
+++ b/src/stores/__tests__/settings-state.test.ts
@@ -1,9 +1,12 @@
 import {
+  adjustPreparationTime,
   adjustTimeLimit,
   customPatternDurationLimits,
   defaultSettingsState,
+  maximumPreparationTimeMs,
   maximumTimeLimitMs,
   mergePersistedSettingsState,
+  minimumPreparationTimeMs,
   normalizePersistedSettingsState,
   setCustomPatternStepValue,
 } from "../settings-state";
@@ -22,6 +25,7 @@ describe("settings state", () => {
       ...defaultSettingsState,
       customPatternEnabled: true,
       customPatternSteps: [1_500, 0, 8_000, 3_500] as [number, number, number, number],
+      preparationTime: 30_000,
       guidedBreathingVoice: "bell" as const,
       timeLimit: 0,
       shouldFollowSystemDarkMode: false,
@@ -37,6 +41,7 @@ describe("settings state", () => {
       customPatternEnabled: "yes",
       customPatternSteps: [-1, Number.NaN, 200_000, 3_000],
       selectedPatternPresetId: "missing-preset",
+      preparationTime: Number.POSITIVE_INFINITY,
       guidedBreathingVoice: "missing-voice",
       timeLimit: Number.POSITIVE_INFINITY,
       shouldFollowSystemDarkMode: null,
@@ -71,6 +76,27 @@ describe("settings state", () => {
   it("clamps every time-limit adjustment inside the supported range", () => {
     expect(adjustTimeLimit(0, -60_000)).toBe(0);
     expect(adjustTimeLimit(maximumTimeLimitMs, 60_000)).toBe(maximumTimeLimitMs);
+  });
+
+  it("clamps every preparation-time adjustment inside the supported range", () => {
+    expect(adjustPreparationTime(minimumPreparationTimeMs, -1_000)).toBe(minimumPreparationTimeMs);
+    expect(adjustPreparationTime(maximumPreparationTimeMs, 1_000)).toBe(maximumPreparationTimeMs);
+  });
+
+  it("rounds persisted preparation time to the displayed whole seconds", () => {
+    expect(normalizePersistedSettingsState({ preparationTime: 3_500 }).preparationTime).toBe(4_000);
+  });
+
+  it.each([
+    [null, defaultSettingsState.preparationTime],
+    ["30 seconds", defaultSettingsState.preparationTime],
+    [Number.NaN, defaultSettingsState.preparationTime],
+    [minimumPreparationTimeMs - 1, minimumPreparationTimeMs],
+    [maximumPreparationTimeMs + 1, maximumPreparationTimeMs],
+  ])("normalizes persisted preparation time %p", (preparationTime, expectedPreparationTime) => {
+    expect(normalizePersistedSettingsState({ preparationTime }).preparationTime).toBe(
+      expectedPreparationTime,
+    );
   });
 
   it("clamps custom steps and ignores invalid indexes", () => {

--- a/src/stores/__tests__/settings.test.ts
+++ b/src/stores/__tests__/settings.test.ts
@@ -62,14 +62,28 @@ describe("settings persistence", () => {
   });
 
   it("restores stored settings and keeps the store actions", async () => {
-    mockGetItem.mockResolvedValue(storedSettings({ theme: "dark", vibrationEnabled: false }));
+    mockGetItem.mockResolvedValue(
+      storedSettings({ theme: "dark", vibrationEnabled: false, preparationTime: 30_000 }),
+    );
 
     const useSettingsStore = await loadSettingsStore();
 
     expect(useSettingsStore.persist.hasHydrated()).toBe(true);
     expect(useSettingsStore.getState().theme).toBe("dark");
     expect(useSettingsStore.getState().vibrationEnabled).toBe(false);
+    expect(useSettingsStore.getState().preparationTime).toBe(30_000);
     expect(typeof useSettingsStore.getState().setTheme).toBe("function");
+  });
+
+  it("adjusts the preparation time through the store actions", async () => {
+    mockGetItem.mockResolvedValue(null);
+    const useSettingsStore = await loadSettingsStore();
+
+    useSettingsStore.getState().increasePreparationTime();
+    expect(useSettingsStore.getState().preparationTime).toBe(4_000);
+
+    useSettingsStore.getState().decreasePreparationTime();
+    expect(useSettingsStore.getState().preparationTime).toBe(3_000);
   });
 
   it("retries a read that failed before it falls back to the defaults", async () => {

--- a/src/stores/settings-state.ts
+++ b/src/stores/settings-state.ts
@@ -10,6 +10,7 @@ export interface PersistedSettingsState {
   customPatternEnabled: boolean;
   customPatternSteps: CustomPatternSteps;
   selectedPatternPresetId: string;
+  preparationTime: number;
   guidedBreathingVoice: GuidedBreathingMode;
   timeLimit: number;
   shouldFollowSystemDarkMode: boolean;
@@ -31,6 +32,9 @@ export const customPatternDurationLimits: [
   [0, ms("99 sec")],
 ];
 export const customPatternStepSizeMs = ms("0.5 sec");
+export const minimumPreparationTimeMs = ms("3 sec");
+export const maximumPreparationTimeMs = ms("60 sec");
+export const preparationTimeStepMs = ms("1 sec");
 export const timeLimitStepMs = ms("1 min");
 export const maximumTimeLimitMs = ms("60 min");
 
@@ -38,6 +42,7 @@ export const defaultSettingsState: PersistedSettingsState = {
   customPatternEnabled: false,
   customPatternSteps: [ms("4 sec"), ms("2 sec"), ms("4 sec"), ms("2 sec")],
   selectedPatternPresetId: "square",
+  preparationTime: minimumPreparationTimeMs,
   guidedBreathingVoice: "paul",
   timeLimit: ms("2 min"),
   shouldFollowSystemDarkMode: true,
@@ -54,6 +59,16 @@ const clampFiniteNumber = (value: unknown, minimum: number, maximum: number, fal
   typeof value === "number" && Number.isFinite(value)
     ? Math.min(maximum, Math.max(minimum, value))
     : fallback;
+
+const normalizePreparationTime = (value: unknown) =>
+  Math.round(
+    clampFiniteNumber(
+      value,
+      minimumPreparationTimeMs,
+      maximumPreparationTimeMs,
+      defaultSettingsState.preparationTime,
+    ) / preparationTimeStepMs,
+  ) * preparationTimeStepMs;
 
 export const setCustomPatternStepValue = (
   steps: CustomPatternSteps,
@@ -75,6 +90,9 @@ export const setCustomPatternStepValue = (
 
 export const adjustTimeLimit = (timeLimit: number, deltaMs: number) =>
   clampFiniteNumber(timeLimit + deltaMs, 0, maximumTimeLimitMs, defaultSettingsState.timeLimit);
+
+export const adjustPreparationTime = (preparationTime: number, deltaMs: number) =>
+  normalizePreparationTime(preparationTime + deltaMs);
 
 export const normalizePersistedSettingsState = (value: unknown): PersistedSettingsState => {
   const candidate = isRecord(value) ? value : {};
@@ -109,6 +127,7 @@ export const normalizePersistedSettingsState = (value: unknown): PersistedSettin
         : defaultSettingsState.customPatternEnabled,
     customPatternSteps,
     selectedPatternPresetId,
+    preparationTime: normalizePreparationTime(candidate.preparationTime),
     guidedBreathingVoice,
     timeLimit: clampFiniteNumber(
       candidate.timeLimit,

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -9,9 +9,11 @@ import {
 } from "zustand/middleware";
 import { patternPresets } from "@breathly/assets/pattern-presets";
 import {
+  adjustPreparationTime,
   adjustTimeLimit,
   defaultSettingsState,
   mergePersistedSettingsState,
+  preparationTimeStepMs,
   setCustomPatternStepValue,
   timeLimitStepMs,
   type PersistedSettingsState,
@@ -25,6 +27,8 @@ interface SettingsStore extends PersistedSettingsState {
   setCustomPatternStep: (stepIndex: number, stepValue: number) => unknown;
   setSelectedPatternPresetId: (patternPresetId: string) => unknown;
   setGuidedBreathingVoice: (guidedBreathingVoice: GuidedBreathingMode) => unknown;
+  increasePreparationTime: () => unknown;
+  decreasePreparationTime: () => unknown;
   increaseTimeLimit: () => unknown;
   decreaseTimeLimit: () => unknown;
   setShouldFollowSystemDarkMode: (shouldFollowSystemDarkMode: boolean) => unknown;
@@ -101,6 +105,14 @@ export const useSettingsStore = create<SettingsStore>()(
         },
         setSelectedPatternPresetId: (selectedPatternPresetId) => set({ selectedPatternPresetId }),
         setGuidedBreathingVoice: (guidedBreathingVoice) => set({ guidedBreathingVoice }),
+        increasePreparationTime: () =>
+          set({
+            preparationTime: adjustPreparationTime(get().preparationTime, preparationTimeStepMs),
+          }),
+        decreasePreparationTime: () =>
+          set({
+            preparationTime: adjustPreparationTime(get().preparationTime, -preparationTimeStepMs),
+          }),
         increaseTimeLimit: () =>
           set({ timeLimit: adjustTimeLimit(get().timeLimit, timeLimitStepMs) }),
         decreaseTimeLimit: () =>


### PR DESCRIPTION
Adds a persisted 3–60 second preparation delay, configurable from Settings. The exercise countdown now uses this value after its subtitle appears. Includes validation for legacy settings, accessibility countdown labels, cancellation on unmount, settings UI integration, and timing coverage.

Closes #124