### PR TITLE
fix: show two-digit exercise time limit

### DIFF
--- a/.maestro/flows/time-limit-display.yaml
+++ b/.maestro/flows/time-limit-display.yaml
@@ -1,0 +1,38 @@
+appId: com.mmazzarolo.breathly
+name: Show two-digit exercise time limit
+---
+- clearState
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: "home.screen"
+    timeout: 10000
+- tapOn:
+    id: "home.customize"
+- extendedWaitUntil:
+    visible:
+      id: "settings.screen"
+    timeout: 5000
+- scrollUntilVisible:
+    element:
+      id: "settings.timer.increase"
+    direction: DOWN
+- tapOn:
+    id: "settings.timer.increase"
+- tapOn:
+    id: "settings.timer.increase"
+- tapOn:
+    id: "settings.timer.increase"
+- tapOn:
+    id: "settings.timer.increase"
+- tapOn:
+    id: "settings.timer.increase"
+- tapOn:
+    id: "settings.timer.increase"
+- tapOn:
+    id: "settings.timer.increase"
+- tapOn:
+    id: "settings.timer.increase"
+- assertVisible:
+    id: "settings.timer.value"
+    text: "10"

--- a/src/screens/settings-screen/__tests__/settings-ui-android.test.tsx
+++ b/src/screens/settings-screen/__tests__/settings-ui-android.test.tsx
@@ -1,0 +1,11 @@
+import { getStepperValueWidth } from "../settings-ui.android";
+
+describe("Android settings stepper", () => {
+  it("reserves enough width for a two-digit timer value", () => {
+    expect(getStepperValueWidth(0)).toBe(48);
+  });
+
+  it("keeps the compact width for decimal breathing-pattern values", () => {
+    expect(getStepperValueWidth(1)).toBe(44);
+  });
+});

--- a/src/screens/settings-screen/settings-ui.android.tsx
+++ b/src/screens/settings-screen/settings-ui.android.tsx
@@ -370,6 +370,8 @@ const SwitchItem: FC<SwitchItemProps & GroupPositionProp> = ({
 const formatStepperValue = (value: number | string | undefined, fractionDigits: number) =>
   typeof value === "number" && fractionDigits > 0 ? value.toFixed(fractionDigits) : `${value}`;
 
+export const getStepperValueWidth = (fractionDigits: number) => (fractionDigits > 0 ? 44 : 48);
+
 const StepperItem: FC<StepperItemProps & GroupPositionProp> = ({
   label,
   secondaryLabel,
@@ -406,7 +408,7 @@ const StepperItem: FC<StepperItemProps & GroupPositionProp> = ({
           <Text
             style={{ textAlign: "center" }}
             modifiers={[
-              widthModifier(fractionDigits > 0 ? 44 : 32),
+              widthModifier(getStepperValueWidth(fractionDigits)),
               ...(testID ? [testTagModifier(`${testID}.value`)] : []),
             ]}
           >


### PR DESCRIPTION
Increased the Android Compose timer-value width from 32dp to 48dp so two-digit minute values remain visible. Added unit coverage for the width rule and a Maestro flow that sets the timer to 10 minutes and verifies the displayed value.

Closes #113