### PR TITLE
feat: publish Android APK releases

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,0 +1,83 @@
+name: Release Android APK
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-android-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    environment: release
+
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify trusted release source
+        run: |
+          test "$GITHUB_REF" = "refs/heads/master"
+          git fetch origin master --quiet
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/master
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+
+      - name: Set up Expo and EAS
+        uses: expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e # v8.2.1
+        with:
+          eas-version: 21.4.0
+          token: ${{ secrets.EXPO_TOKEN }}
+          packager: bun
+
+      - name: Install locked dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build signed Android APK
+        id: build
+        run: |
+          eas build --platform android --profile preview --non-interactive --wait --json > eas-build.json
+          node scripts/create-android-release.mjs eas-build.json app.json >> "$GITHUB_OUTPUT"
+
+      - name: Download APK and checksum
+        id: artifact
+        env:
+          APK_URL: ${{ steps.build.outputs.apk_url }}
+        run: |
+          apk="Breathly.apk"
+          curl --fail --location --retry 3 --retry-all-errors "$APK_URL" --output "$apk"
+          sha256sum "$apk" > "${apk}.sha256"
+          echo "apk=$apk" >> "$GITHUB_OUTPUT"
+          echo "checksum=${apk}.sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Create release tag
+        env:
+          RELEASE_TAG: ${{ steps.build.outputs.release_tag }}
+        run: |
+          git tag "$RELEASE_TAG" "$GITHUB_SHA"
+          git push origin "refs/tags/$RELEASE_TAG"
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        with:
+          tag_name: ${{ steps.build.outputs.release_tag }}
+          name: ${{ steps.build.outputs.release_name }}
+          generate_release_notes: true
+          files: |
+            ${{ steps.artifact.outputs.apk }}
+            ${{ steps.artifact.outputs.checksum }}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ Breathly is a tiny React-Native app that I developed in my free time to refine m
 
 I hope the source code will be useful to someone.
 
+## Android APK releases
+
+Run the **Release Android APK** workflow from `master` to build and publish a signed Android APK and its
+SHA-256 checksum in GitHub Releases. The workflow creates the `android-<version>-(<versionCode>)` tag from
+the version code returned by EAS, so the tag always identifies the published APK.
+
+Before the first release, configure a protected GitHub Environment named `release`, add an `EXPO_TOKEN`
+environment secret that can access the configured EAS project, and require a reviewer for deployments.
+Run `eas build:version:set --platform android` to initialize EAS remote version management with a version
+code greater than every already distributed Breathly APK. Keep the EAS CLI version in `eas.json` and the
+workflow in sync when upgrading it. An APK signed with a different key cannot update an installed F-Droid
+version; uninstall that version before installing the GitHub APK.
+
 ## Resources and acknowledgements
 
 - I created the app icon using [SVGWave](https://svgwave.in/) and edited using [Affinity Photo](https://svgwave.in/).

--- a/eas.json
+++ b/eas.json
@@ -1,6 +1,7 @@
 {
   "cli": {
-    "version": ">= 2.6.0",
+    "version": "21.4.0",
+    "appVersionSource": "remote",
     "promptToConfigurePushNotifications": false
   },
   "build": {
@@ -9,7 +10,8 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "autoIncrement": true
     },
     "production": {}
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "test": "jest --runInBand",
+    "test:release-android": "node --test scripts/create-android-release.test.mjs",
     "test:watch": "jest --watch",
     "e2e": "maestro test .maestro/flows",
     "e2e:android": "maestro --platform=android test .maestro/flows",
@@ -22,7 +23,7 @@
     "e2e:build:ios": "expo run:ios --configuration Release --no-bundler",
     "visual:capture": "bash scripts/visual-e2e/capture-installed.sh",
     "visual:compare": "node scripts/visual-e2e/compare.mjs",
-    "validate:static": "bun run typecheck && bun run lint && bun run format:check && bun run test",
+    "validate:static": "bun run typecheck && bun run lint && bun run format:check && bun run test && bun run test:release-android",
     "validate:expo": "expo install --check && expo-doctor",
     "validate:bundles": "expo export --platform all --output-dir dist/validate-export --clear",
     "validate": "bun run validate:static && bun run validate:expo"

--- a/scripts/create-android-release.mjs
+++ b/scripts/create-android-release.mjs
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+function requireString(value, name) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`EAS build response has no ${name}`);
+  }
+
+  return value;
+}
+
+export function createAndroidRelease(builds, appConfig) {
+  if (!Array.isArray(builds) || builds.length !== 1) {
+    throw new Error("EAS must return exactly one Android build");
+  }
+
+  const build = builds[0];
+  const appVersion = requireString(appConfig?.expo?.version, "Expo version");
+  const appBuildVersion = requireString(build?.appBuildVersion, "Android version code");
+  const archiveUrl = requireString(build?.artifacts?.applicationArchiveUrl, "APK URL");
+
+  if (!/^[0-9A-Za-z][0-9A-Za-z.+-]*$/.test(appVersion)) {
+    throw new Error("Expo version cannot be used in an Android release tag");
+  }
+
+  if (!/^[1-9][0-9]*$/.test(appBuildVersion)) {
+    throw new Error("EAS returned an invalid Android version code");
+  }
+
+  if (archiveUrl.includes("\n") || archiveUrl.includes("\r")) {
+    throw new Error("EAS returned an invalid APK URL");
+  }
+
+  const parsedApkUrl = new URL(archiveUrl);
+  if (parsedApkUrl.protocol !== "https:") {
+    throw new Error("EAS returned an APK URL without HTTPS");
+  }
+
+  return {
+    apkUrl: archiveUrl,
+    releaseName: `Android ${appVersion} (${appBuildVersion})`,
+    releaseTag: `android-${appVersion}-(${appBuildVersion})`,
+  };
+}
+
+export function formatGitHubOutputs(release) {
+  return [
+    `apk_url=${release.apkUrl}`,
+    `release_name=${release.releaseName}`,
+    `release_tag=${release.releaseTag}`,
+    "",
+  ].join("\n");
+}
+
+function main() {
+  const [buildPath, appConfigPath] = process.argv.slice(2);
+  if (!buildPath || !appConfigPath) {
+    throw new Error("Usage: create-android-release.mjs <eas-build.json> <app.json>");
+  }
+
+  const builds = JSON.parse(fs.readFileSync(buildPath, "utf8"));
+  const appConfig = JSON.parse(fs.readFileSync(appConfigPath, "utf8"));
+  process.stdout.write(formatGitHubOutputs(createAndroidRelease(builds, appConfig)));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/create-android-release.test.mjs
+++ b/scripts/create-android-release.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createAndroidRelease, formatGitHubOutputs } from "./create-android-release.mjs";
+
+const appConfig = { expo: { version: "2.2.0" } };
+const build = {
+  appBuildVersion: "3145751",
+  artifacts: {
+    applicationArchiveUrl: "https://example.test/Breathly.apk?signature=abc",
+  },
+};
+
+test("uses the version code returned by EAS for the release tag", () => {
+  const release = createAndroidRelease([build], appConfig);
+
+  assert.deepEqual(release, {
+    apkUrl: "https://example.test/Breathly.apk?signature=abc",
+    releaseName: "Android 2.2.0 (3145751)",
+    releaseTag: "android-2.2.0-(3145751)",
+  });
+  assert.equal(
+    formatGitHubOutputs(release),
+    "apk_url=https://example.test/Breathly.apk?signature=abc\n" +
+      "release_name=Android 2.2.0 (3145751)\n" +
+      "release_tag=android-2.2.0-(3145751)\n",
+  );
+});
+
+test("rejects an incomplete EAS build response", () => {
+  assert.throws(() => createAndroidRelease([], appConfig), /exactly one Android build/);
+  assert.throws(
+    () => createAndroidRelease([{ artifacts: build.artifacts }], appConfig),
+    /Android version code/,
+  );
+  assert.throws(() => createAndroidRelease([{ ...build, artifacts: {} }], appConfig), /APK URL/);
+});
+
+test("rejects release values that cannot be safely published", () => {
+  assert.throws(
+    () => createAndroidRelease([{ ...build, appBuildVersion: "0" }], appConfig),
+    /invalid Android version code/,
+  );
+  assert.throws(
+    () =>
+      createAndroidRelease(
+        [
+          {
+            ...build,
+            artifacts: { applicationArchiveUrl: "http://example.test/app.apk" },
+          },
+        ],
+        appConfig,
+      ),
+    /without HTTPS/,
+  );
+  assert.throws(
+    () =>
+      createAndroidRelease(
+        [
+          {
+            ...build,
+            artifacts: {
+              applicationArchiveUrl: "https://example.test/app.apk\nrelease_tag=bad",
+            },
+          },
+        ],
+        appConfig,
+      ),
+    /invalid APK URL/,
+  );
+  assert.throws(
+    () => createAndroidRelease([build], { expo: { version: "2.2.0\ninvalid" } }),
+    /cannot be used/,
+  );
+});


### PR DESCRIPTION
Adds a manual GitHub Actions workflow that builds a signed Android APK with EAS and publishes it with a SHA-256 checksum to GitHub Releases.

The release tag is generated from the actual EAS `versionCode`, then atomically pushed on the release commit before publishing. This prevents an APK from being attached to a conflicting tag.

The change also enables remote Android version management with auto-increment for the preview APK profile, pins the EAS CLI version, documents the required GitHub/EAS setup, and adds tests for EAS build output validation.

Closes #116