### PR TITLE
feat: add navigation bar visibility option

### DIFF
--- a/src/core/entry-point.tsx
+++ b/src/core/entry-point.tsx
@@ -36,8 +36,11 @@ const Main: FC = () => {
   const [areFontsLoaded, fontLoadError] = Font.useFonts(fontAssets);
   const theme = useSettingsStore((state) => state.theme);
   const shouldFollowSystemDarkMode = useSettingsStore((state) => state.shouldFollowSystemDarkMode);
+  const shouldKeepNavigationBarVisible = useSettingsStore(
+    (state) => state.shouldKeepNavigationBarVisible,
+  );
   const hydrated = useHydration();
-  useStickyImmersiveReset();
+  useStickyImmersiveReset(shouldKeepNavigationBarVisible);
   useThemedStatusBar();
 
   // Native views take their colours from the system appearance, not from the app's own

--- a/src/screens/settings-screen/settings-screen.tsx
+++ b/src/screens/settings-screen/settings-screen.tsx
@@ -38,6 +38,12 @@ export const SettingsRootScreen: FC<
   const setTheme = useSettingsStore((state) => state.setTheme);
   const vibrationEnabled = useSettingsStore((state) => state.vibrationEnabled);
   const setVibrationEnabled = useSettingsStore((state) => state.setVibrationEnabled);
+  const shouldKeepNavigationBarVisible = useSettingsStore(
+    (state) => state.shouldKeepNavigationBarVisible,
+  );
+  const setShouldKeepNavigationBarVisible = useSettingsStore(
+    (state) => state.setShouldKeepNavigationBarVisible,
+  );
 
   React.useEffect(() => {
     // Use `setOptions` to update the button that we previously specified
@@ -134,6 +140,19 @@ export const SettingsRootScreen: FC<
               testID="settings.vibration"
             />
           </SettingsUI.Section>
+          {Platform.OS === "android" && (
+            <SettingsUI.Section label="Navigation">
+              <SettingsUI.SwitchItem
+                label="Show navigation buttons"
+                secondaryLabel="Keep Android navigation buttons visible"
+                iconName="navigate"
+                iconBackgroundColor="#86efac"
+                value={shouldKeepNavigationBarVisible}
+                onValueChange={setShouldKeepNavigationBarVisible}
+                testID="settings.navigation-buttons"
+              />
+            </SettingsUI.Section>
+          )}
           <SettingsUI.Section label="Timer" hideBottomBorderWeb>
             <SettingsUI.StepperItem
               label="Exercise timer"

--- a/src/stores/__tests__/settings-state.test.ts
+++ b/src/stores/__tests__/settings-state.test.ts
@@ -27,6 +27,7 @@ describe("settings state", () => {
       shouldFollowSystemDarkMode: false,
       theme: "dark" as const,
       vibrationEnabled: false,
+      shouldKeepNavigationBarVisible: true,
     };
 
     expect(normalizePersistedSettingsState(validSettings)).toEqual(validSettings);
@@ -42,6 +43,7 @@ describe("settings state", () => {
       shouldFollowSystemDarkMode: null,
       theme: "sepia",
       vibrationEnabled: 1,
+      shouldKeepNavigationBarVisible: "always",
     });
 
     expect(normalized).toEqual({

--- a/src/stores/__tests__/settings.test.ts
+++ b/src/stores/__tests__/settings.test.ts
@@ -62,13 +62,20 @@ describe("settings persistence", () => {
   });
 
   it("restores stored settings and keeps the store actions", async () => {
-    mockGetItem.mockResolvedValue(storedSettings({ theme: "dark", vibrationEnabled: false }));
+    mockGetItem.mockResolvedValue(
+      storedSettings({
+        theme: "dark",
+        vibrationEnabled: false,
+        shouldKeepNavigationBarVisible: true,
+      }),
+    );
 
     const useSettingsStore = await loadSettingsStore();
 
     expect(useSettingsStore.persist.hasHydrated()).toBe(true);
     expect(useSettingsStore.getState().theme).toBe("dark");
     expect(useSettingsStore.getState().vibrationEnabled).toBe(false);
+    expect(useSettingsStore.getState().shouldKeepNavigationBarVisible).toBe(true);
     expect(typeof useSettingsStore.getState().setTheme).toBe("function");
   });
 

--- a/src/stores/settings-state.ts
+++ b/src/stores/settings-state.ts
@@ -15,6 +15,7 @@ export interface PersistedSettingsState {
   shouldFollowSystemDarkMode: boolean;
   theme: Theme;
   vibrationEnabled: boolean;
+  shouldKeepNavigationBarVisible: boolean;
 }
 
 // A tuple, not an array: `normalizePersistedSettingsState` maps over this to build the four
@@ -43,6 +44,7 @@ export const defaultSettingsState: PersistedSettingsState = {
   shouldFollowSystemDarkMode: true,
   theme: "light",
   vibrationEnabled: true,
+  shouldKeepNavigationBarVisible: false,
 };
 
 const guidedBreathingModes: GuidedBreathingMode[] = ["laura", "paul", "bell", "disabled"];
@@ -125,6 +127,10 @@ export const normalizePersistedSettingsState = (value: unknown): PersistedSettin
       typeof candidate.vibrationEnabled === "boolean"
         ? candidate.vibrationEnabled
         : defaultSettingsState.vibrationEnabled,
+    shouldKeepNavigationBarVisible:
+      typeof candidate.shouldKeepNavigationBarVisible === "boolean"
+        ? candidate.shouldKeepNavigationBarVisible
+        : defaultSettingsState.shouldKeepNavigationBarVisible,
   };
 };
 

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -30,6 +30,7 @@ interface SettingsStore extends PersistedSettingsState {
   setShouldFollowSystemDarkMode: (shouldFollowSystemDarkMode: boolean) => unknown;
   setTheme: (theme: Theme) => unknown;
   setVibrationEnabled: (vibrationEnabled: boolean) => unknown;
+  setShouldKeepNavigationBarVisible: (shouldKeepNavigationBarVisible: boolean) => unknown;
 }
 
 const readRetryDelayMs = 50;
@@ -109,6 +110,8 @@ export const useSettingsStore = create<SettingsStore>()(
           set({ shouldFollowSystemDarkMode }),
         setTheme: (theme) => set({ theme }),
         setVibrationEnabled: (vibrationEnabled) => set({ vibrationEnabled }),
+        setShouldKeepNavigationBarVisible: (shouldKeepNavigationBarVisible) =>
+          set({ shouldKeepNavigationBarVisible }),
       }),
       {
         name: "settings-storage",

--- a/src/utils/__tests__/use-sticky-immersive-reset.test.tsx
+++ b/src/utils/__tests__/use-sticky-immersive-reset.test.tsx
@@ -1,0 +1,79 @@
+jest.mock("expo-navigation-bar", () => ({
+  NavigationBar: { setHidden: jest.fn() },
+  useVisibility: jest.fn(),
+}));
+
+jest.mock("expo-status-bar", () => ({ setStatusBarHidden: jest.fn() }));
+
+import { act, render } from "@testing-library/react-native";
+import { NavigationBar, useVisibility } from "expo-navigation-bar";
+import React from "react";
+import { Platform } from "react-native";
+import { useStickyImmersiveReset } from "../use-sticky-immersive-reset";
+
+const mockSetHidden = NavigationBar.setHidden as jest.Mock;
+const mockUseVisibility = useVisibility as jest.Mock;
+const originalPlatform = Platform.OS;
+
+const ImmersiveReset = ({
+  shouldKeepNavigationBarVisible,
+}: {
+  shouldKeepNavigationBarVisible: boolean;
+}) => {
+  useStickyImmersiveReset(shouldKeepNavigationBarVisible);
+  return null;
+};
+
+beforeAll(() => {
+  Object.defineProperty(Platform, "OS", { configurable: true, value: "android" });
+});
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockUseVisibility.mockReturnValue("visible");
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  Object.defineProperty(Platform, "OS", { configurable: true, value: originalPlatform });
+});
+
+describe("sticky immersive navigation", () => {
+  it("keeps navigation buttons visible without scheduling another hide", async () => {
+    const { unmount } = await render(<ImmersiveReset shouldKeepNavigationBarVisible />);
+
+    expect(mockSetHidden).toHaveBeenCalledWith(false);
+
+    await act(() => jest.advanceTimersByTime(3_000));
+
+    expect(mockSetHidden).not.toHaveBeenCalledWith(true);
+    await unmount();
+  });
+
+  it("cancels a pending hide when navigation buttons are enabled", async () => {
+    const { rerender, unmount } = await render(
+      <ImmersiveReset shouldKeepNavigationBarVisible={false} />,
+    );
+
+    await rerender(<ImmersiveReset shouldKeepNavigationBarVisible />);
+    await act(() => jest.advanceTimersByTime(3_000));
+
+    expect(mockSetHidden).toHaveBeenCalledWith(false);
+    expect(mockSetHidden).not.toHaveBeenCalledWith(true);
+    await unmount();
+  });
+
+  it("returns to sticky immersive mode when navigation buttons are disabled", async () => {
+    const { rerender, unmount } = await render(<ImmersiveReset shouldKeepNavigationBarVisible />);
+
+    await rerender(<ImmersiveReset shouldKeepNavigationBarVisible={false} />);
+    await act(() => jest.advanceTimersByTime(3_000));
+
+    expect(mockSetHidden).toHaveBeenLastCalledWith(true);
+    await unmount();
+  });
+});

--- a/src/utils/use-sticky-immersive-reset.ts
+++ b/src/utils/use-sticky-immersive-reset.ts
@@ -21,20 +21,24 @@ export function initializeImmersiveMode() {
 // Hide the navigation bar after a certain duration
 const HIDE_NAVIGATION_BAR_AFTER_MS = ms("3 sec");
 
-export function useStickyImmersiveReset() {
+export function useStickyImmersiveReset(shouldKeepNavigationBarVisible: boolean) {
   const visibility = useVisibility();
 
   useEffect(() => {
     if (Platform.OS !== "android") return;
-    if (visibility === "visible") {
-      const interval = setTimeout(() => {
-        NavigationBar.setHidden(true);
-        setStatusBarHidden(true, "none");
-      }, HIDE_NAVIGATION_BAR_AFTER_MS);
-
-      return () => {
-        clearTimeout(interval);
-      };
+    if (shouldKeepNavigationBarVisible) {
+      NavigationBar.setHidden(false);
+      return;
     }
-  }, [visibility]);
+    if (visibility !== "visible") return;
+
+    const timeout = setTimeout(() => {
+      NavigationBar.setHidden(true);
+      setStatusBarHidden(true, "none");
+    }, HIDE_NAVIGATION_BAR_AFTER_MS);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [shouldKeepNavigationBarVisible, visibility]);
 }


### PR DESCRIPTION
Adds an Android-only setting to keep system navigation buttons visible. The preference is persisted, defaults to the existing immersive behavior, cancels pending auto-hide timers when enabled, and restores sticky immersive mode when disabled.

Includes tests for persisted setting migration and navigation-bar timer behavior.

Closes #119