### PR TITLE
feat: add breathing technique presets

### DIFF
--- a/src/assets/__tests__/pattern-presets.test.ts
+++ b/src/assets/__tests__/pattern-presets.test.ts
@@ -1,0 +1,33 @@
+import ms from "ms";
+import { patternPresets } from "../pattern-presets";
+
+describe("pattern presets", () => {
+  it("includes the new breathing techniques with their intended patterns", () => {
+    expect(patternPresets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "advanced-5-7-9",
+          steps: [ms("5s"), ms("7s"), ms("9s"), 0],
+        }),
+        expect.objectContaining({
+          id: "ratio-1-4-2",
+          steps: [ms("5s"), ms("20s"), ms("10s"), 0],
+        }),
+        expect.objectContaining({
+          id: "rectangular",
+          steps: [ms("5s"), ms("8s"), ms("5s"), ms("8s")],
+        }),
+        expect.objectContaining({
+          id: "wim-hof",
+          steps: [ms("2s"), 0, ms("2s"), 0],
+        }),
+      ]),
+    );
+  });
+
+  it("keeps preset ids unique", () => {
+    const ids = patternPresets.map((preset) => preset.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/src/assets/pattern-presets.ts
+++ b/src/assets/pattern-presets.ts
@@ -9,10 +9,22 @@ import { PatternPreset } from "@breathly/types/pattern-preset";
 // assertion.
 export const patternPresets: [PatternPreset, ...PatternPreset[]] = [
   {
+    id: "ratio-1-4-2",
+    name: "1-4-2 Ratio",
+    steps: [ms("5s"), ms("20s"), ms("10s"), 0],
+    description: "An advanced breathing ratio with a long hold after the inhale.",
+  },
+  {
     id: "deep-calm",
     name: "4-7-8 Deep Calm",
     steps: [ms("4s"), ms("7s"), ms("8s"), 0],
     description: "A natural tranquilizer for the nervous system. Do it at least twice a day.",
+  },
+  {
+    id: "advanced-5-7-9",
+    name: "Advanced 5-7-9",
+    steps: [ms("5s"), ms("7s"), ms("9s"), 0],
+    description: "A longer cycle with a hold after the inhale and an extended exhale.",
   },
   {
     id: "awake",
@@ -42,6 +54,12 @@ export const patternPresets: [PatternPreset, ...PatternPreset[]] = [
     description: "A main component of yoga, an exercise for physical and mental wellness.",
   },
   {
+    id: "rectangular",
+    name: "Rectangular",
+    steps: [ms("5s"), ms("8s"), ms("5s"), ms("8s")],
+    description: "A slower box-breathing rhythm with longer holds between equal breaths.",
+  },
+  {
     id: "square",
     name: "Square",
     steps: [ms("4s"), ms("4s"), ms("4s"), ms("4s")],
@@ -54,5 +72,12 @@ export const patternPresets: [PatternPreset, ...PatternPreset[]] = [
     steps: [ms("7s"), 0, ms("7s"), 0],
     description:
       "Balance influence on the cardiorespiratory system, release feelings of irritation, and calm the mind and body.",
+  },
+  {
+    id: "wim-hof",
+    name: "Wim Hof Method",
+    steps: [ms("2s"), 0, ms("2s"), 0],
+    description:
+      "A steady rhythm for the active breathing phase. It does not include the method's retention phase.",
   },
 ];


### PR DESCRIPTION
- Adds four presets to the existing technique catalogue:
  - `1-4-2 Ratio` (`5-20-10-0`)
  - `Advanced 5-7-9` (`5-7-9-0`)
  - `Rectangular` (`5-8-5-8`)
  - `Wim Hof Method` (`2-0-2-0`)
- Uses the current `PatternPreset` structure without introducing an unused color field.
- Documents that the Wim Hof preset covers the active breathing phase only; retention rounds need a separate exercise-engine feature.
- Keeps stable preset IDs for persisted settings compatibility.
- Adds tests for the exact new patterns and duplicate IDs.


Closes #80